### PR TITLE
Refactoring

### DIFF
--- a/src/com/aventura/context/RenderContext.java
+++ b/src/com/aventura/context/RenderContext.java
@@ -77,8 +77,11 @@ public class RenderContext {
 	public Color lightVectorsColor = Color.YELLOW;
 
 	
-	
+	// Default RenderContext to be used for easy display
+	public static RenderContext RENDER_STANDARD_PLAIN = new RenderContext(RenderContext.RENDERING_TYPE_PLAIN, RenderContext.DISPLAY_LANDMARK_DISABLED);
+	public static RenderContext RENDER_STANDARD_PLAIN_WITH_LANDMARKS = new RenderContext(RenderContext.RENDERING_TYPE_PLAIN, RenderContext.DISPLAY_LANDMARK_ENABLED);
 	public static RenderContext RENDER_STANDARD_INTERPOLATE = new RenderContext(RENDERING_TYPE_INTERPOLATE, DISPLAY_LANDMARK_DISABLED);
+	public static RenderContext RENDER_STANDARD_INTERPOLATE_WITH_LANDMARKS = new RenderContext(RENDERING_TYPE_INTERPOLATE, DISPLAY_LANDMARK_ENABLED);
 	public static RenderContext RENDER_DEFAULT = new RenderContext(RENDERING_TYPE_LINE, DISPLAY_LANDMARK_ENABLED);
 	public static RenderContext RENDER_DEFAULT_ALL_ENABLED = new RenderContext(RENDERING_TYPE_LINE, DISPLAY_LANDMARK_ENABLED, DISPLAY_NORMALS_ENABLED, DISPLAY_LIGHT_VECTORS_ENABLED);
 	

--- a/src/com/aventura/engine/ModelView.java
+++ b/src/com/aventura/engine/ModelView.java
@@ -1,10 +1,7 @@
 package com.aventura.engine;
 
 import com.aventura.math.vector.Matrix4;
-import com.aventura.math.vector.Vector3;
-import com.aventura.math.vector.Vector4;
-import com.aventura.model.world.Segment;
-import com.aventura.model.world.Triangle;
+import com.aventura.model.world.Element;
 import com.aventura.model.world.Vertex;
 import com.aventura.tools.tracing.Tracer;
 
@@ -160,6 +157,17 @@ public class ModelView {
 		if (v.getNormal() != null) {
 			v.setProjNormal(transformation.times(v.getNormal().V4()).V3());
 			v.setWorldNormal(model.times(v.getNormal().V4()).V3());
+		}
+	}
+	
+	/**
+	 * Transform all vertices of an Element
+	 * 
+	 * @param e the Element
+	 */
+	public void transformVertices(Element e) {
+		for (int i=0; i<e.getNbOfVertices(); i++) {
+			transform(e.getVertex(i));
 		}
 	}
 

--- a/src/com/aventura/engine/ModelView.java
+++ b/src/com/aventura/engine/ModelView.java
@@ -110,7 +110,6 @@ public class ModelView {
 		this.projection = projection;
 		if (Tracer.info) Tracer.traceInfo(this.getClass(), "View matrix:\n"+ view);
 		if (Tracer.info) Tracer.traceInfo(this.getClass(), "Projection matrix:\n"+ projection);
-		
 	}
 	
 	/**
@@ -149,33 +148,6 @@ public class ModelView {
 		if (Tracer.info) Tracer.traceInfo(this.getClass(), "Full transformation matrix:\n"+ transformation);
 	}
 	
-	
-	/**
-	 * Return a new Vector4 resulting from the ModelView transformation ("projection") of the provided Vector4
-	 * TransformedVector = [4x4 Transformation Matrix] * OriginalVector
-	 * 
-	 * @param v the Vector4 to be transformed 
-	 * @return a newly created Vector4 resulting from the transformation
-	 */
-	public Vector4 modelToClip(Vector4 v) {
-		return transformation.times(v);
-	}
-	
-	/**
-	 * Return a new Vector3 resulting from the ModelView transformation ("projection") of the provided Vector3
-	 * This methods calls the Vector4 transform(Vector4 v) methods
-	 * 
-	 * Caution: this method relies on Matrix4 / Vector4 computation hence creates new intermediate objects.
-	 * It is less effective in terms of performance and memory usage than the Vector4 transform method.
-	 * 
-	 * @param v the Vector3 to be transformed 
-	 * @return a newly created Vector3 resulting from the transformation
-	 */
-	public Vector3 modelToClip(Vector3 v) {
-		Vector4 v4 = v.V4();
-		return modelToClip(v4).V3();
-	}
-				
 	/**
 	 * Fully compute Vertex projections resulting from the ModelView transformation for both ModelToWorld and ModelToClip projections
 	 * Complete the provided Vertex with projection data but do not modify original position data

--- a/src/com/aventura/engine/ModelView.java
+++ b/src/com/aventura/engine/ModelView.java
@@ -149,63 +149,6 @@ public class ModelView {
 		if (Tracer.info) Tracer.traceInfo(this.getClass(), "Full transformation matrix:\n"+ transformation);
 	}
 	
-	/**
-	 * Return a new Segment containing (new) projected vertices
-	 * Relies on the transform method transforming vertices
-	 * 
-	 * @param l the Segment to transform
-	 * @return the new Segment
-	 */
-	public Segment modelToClip(Segment l) {
-		//if (Tracer.function) Tracer.traceFunction(this.getClass(), "transform line: "+l);
-		
-		Segment transformed = new Segment();
-		
-		transformed.setV1(modelToClip(l.getV1()));
-		transformed.setV2(modelToClip(l.getV2()));
-		
-		//if (Tracer.info) Tracer.traceInfo(this.getClass(), "transformed line: "+ transformed);
-		
-		return transformed;
-	}
-	
-	/**
-	 * Return a new triangle containing (new) projected vertices
-	 * Relies on the transform method transforming vertices
-	 * 
-	 * @param t the triangle to transform
-	 * @return the new triangle
-	 */
-	public Triangle modelToClip(Triangle t) {
-		//if (Tracer.function) Tracer.traceFunction(this.getClass(), "transform triangle: "+t);
-		
-		Triangle transformed = new Triangle();
-		
-		transformed.setV1(modelToClip(t.getV1()));
-		transformed.setV2(modelToClip(t.getV2()));
-		transformed.setV3(modelToClip(t.getV3()));
-		//if (t.getNormal()!=null) transformed.setNormal(transform(t.getNormal()));
-
-		
-		//if (Tracer.info) Tracer.traceInfo(this.getClass(), "transformed triangle: "+ transformed);
-		
-		return transformed;
-	}
-	
-	/**
-	 * Return a new Vertex resulting from the ModelView transformation ("projection") of the provided Vertex
-	 * Do not modify the provided Vertex.
-	 * 
-	 * @param v the provided Vertex (left unchanged)
-	 * @return the new projected Vertex
-	 */
-	public Vertex modelToClip(Vertex v) {
-		// Create a new Vertex having its Vector4 position set to the resulting of the transformation of the provided Vertex's 
-		// Vector4 position by the transformation Matrix
-		Vertex transformed = new Vertex(transformation.times(v.getPosition()));
-		// Return the newly created Vertex (hence preserve the original Vertex of the Element)
-		return transformed;
-	}
 	
 	/**
 	 * Return a new Vector4 resulting from the ModelView transformation ("projection") of the provided Vector4
@@ -229,34 +172,24 @@ public class ModelView {
 	 * @return a newly created Vector3 resulting from the transformation
 	 */
 	public Vector3 modelToClip(Vector3 v) {
-		Vector4 v4 = v.getVector4();
-		return modelToClip(v4).getVector3();
+		Vector4 v4 = v.V4();
+		return modelToClip(v4).V3();
 	}
-	
-	
-	public Triangle modelToWorld(Triangle t){
-		Triangle transformed = new Triangle(t);
-		
-		transformed.setV1(modelToWorld(t.getV1()));
-		transformed.setV2(modelToWorld(t.getV2()));
-		transformed.setV3(modelToWorld(t.getV3()));
-		if (t.getNormal() != null) {
-			transformed.setNormal(model.times(t.getNormal().getVector4()));
-		}
-		return transformed;
-	}
-	
-	public Vertex modelToWorld(Vertex v) {
-		Vertex transformed;
+				
+	/**
+	 * Fully compute Vertex projections resulting from the ModelView transformation for both ModelToWorld and ModelToClip projections
+	 * Complete the provided Vertex with projection data but do not modify original position data
+	 * 
+	 * @param v the provided Vertex
+	 */
+	public void transform(Vertex v) {
+		v.setProjPos(transformation.times(v.getPos()));
+		v.setWorldPos(model.times(v.getPos()));
 		if (v.getNormal() != null) {
-			transformed = new Vertex(model.times(v.getPosition()), model.times(v.getNormalV4()));
-		} else {
-			transformed = new Vertex(model.times(v.getPosition()));
+			v.setProjNormal(transformation.times(v.getNormal().V4()).V3());
+			v.setWorldNormal(model.times(v.getNormal().V4()).V3());
 		}
-		// Return the newly created Vertex (hence preserve the original Vertex of the Element)
-		return transformed;
 	}
-	
 
 
 }

--- a/src/com/aventura/engine/ModelView.java
+++ b/src/com/aventura/engine/ModelView.java
@@ -84,7 +84,7 @@ public class ModelView {
 	Matrix4 model;
 	
 	// This matrix is the result of the multiplication of all Matrices
-	Matrix4 transformation;
+	Matrix4 full;
 	
 	/**
 	 * Default constructor.
@@ -141,8 +141,8 @@ public class ModelView {
 	 */
 	public void computeTransformation() {
 		if (Tracer.function) Tracer.traceFunction(this.getClass(), "computeTransformation()");
-		transformation = projection.times(view.times(model));
-		if (Tracer.info) Tracer.traceInfo(this.getClass(), "Full transformation matrix:\n"+ transformation);
+		full = projection.times(view.times(model));
+		if (Tracer.info) Tracer.traceInfo(this.getClass(), "Full transformation matrix:\n"+ full);
 	}
 	
 	/**
@@ -152,10 +152,10 @@ public class ModelView {
 	 * @param v the provided Vertex
 	 */
 	public void transform(Vertex v) {
-		v.setProjPos(transformation.times(v.getPos()));
+		v.setProjPos(full.times(v.getPos()));
 		v.setWorldPos(model.times(v.getPos()));
 		if (v.getNormal() != null) {
-			v.setProjNormal(transformation.times(v.getNormal().V4()).V3());
+			v.setProjNormal(full.times(v.getNormal().V4()).V3());
 			v.setWorldNormal(model.times(v.getNormal().V4()).V3());
 		}
 	}
@@ -170,6 +170,5 @@ public class ModelView {
 			transform(e.getVertex(i));
 		}
 	}
-
 
 }

--- a/src/com/aventura/engine/Rasterizer.java
+++ b/src/com/aventura/engine/Rasterizer.java
@@ -109,6 +109,14 @@ public class Rasterizer {
 		}
 	}
 	
+	protected double xScreen(Vertex v) {
+		return xScreen(v.getProjPos());
+	}
+	
+	protected double yScreen(Vertex v) {
+		return yScreen(v.getProjPos());
+	}
+	
 	protected double xScreen(Vector4 v) {
 		return v.get3DX()*graphic.getPixelHalfWidth();
 	}
@@ -116,6 +124,8 @@ public class Rasterizer {
 	protected double yScreen(Vector4 v) {
 		return v.get3DY()*graphic.getPixelHalfHeight();
 	}
+	
+
 	
 	// Method for Segment only Rendering
 	//
@@ -139,14 +149,12 @@ public class Rasterizer {
 	public void drawLine(Vertex v1, Vertex v2) {
 
 		int x1, y1, x2, y2;	
-		x1 = (int)(xScreen(v1.getPosition()));
-		y1 = (int)(yScreen(v1.getPosition()));
-		x2 = (int)(xScreen(v2.getPosition()));
-		y2 = (int)(yScreen(v2.getPosition()));
+		x1 = (int)(xScreen(v1));
+		y1 = (int)(yScreen(v1));
+		x2 = (int)(xScreen(v2));
+		y2 = (int)(yScreen(v2));
 
 		view.drawLine(x1, y1, x2, y2);
-		//bressenham_short((short)x1, (short)y1, (short)x2, (short)y2);
-		//bressenham_int(x1, y1, x2, y2);
 	}
 
 	public void drawLine(Vertex v1, Vertex v2, Color c) {
@@ -165,16 +173,14 @@ public class Rasterizer {
 	public void drawVectorFromPosition(Vertex position, Vector3 vector) {
 		
 		int x1, y1, x2, y2;
-		x1 = (int)(xScreen(position.getPosition()));
-		y1 = (int)(yScreen(position.getPosition()));
+		x1 = (int)(xScreen(position));
+		y1 = (int)(yScreen(position));
 		
-		Vector4 p = position.getPosition().plus(vector); 
+		Vector4 p = position.getPos().plus(vector); 
 		x2 = (int)(xScreen(p));
 		y2 = (int)(yScreen(p));
 
 		view.drawLine(x1, y1, x2, y2);
-		//bressenham_short((short)x1, (short)y1, (short)x2, (short)y2);
-		//bressenham_int(x1, y1, x2, y2);
 	}
 	
 	//
@@ -185,15 +191,14 @@ public class Rasterizer {
 	 * Extrapolated from:
 	 * https://www.davrous.com/2013/06/21/tutorial-part-4-learning-how-to-write-a-3d-software-engine-in-c-ts-or-js-rasterization-z-buffering/
 	 * 
-	 * @param tf the (transformed) triangle to render
-	 * @param to the (original) triangle
+	 * @param t the triangle to render
 	 * @param col
 	 */
-	public void rasterizeTriangle(Triangle tf, Triangle to, Color c, boolean interpolate) {
+	public void rasterizeTriangle(Triangle t, Color c, boolean interpolate) {
 		
 		if (Tracer.function) Tracer.traceFunction(this.getClass(), "Rasterize triangle. Color: "+c);
 		
-		Color col = c; // Let's initialize the base color with the one of the triangle
+		Color col = c; // Let's initialize the base color with the provided one (from triangle or default color)
 		Color c1 = null, c2 = null, c3 = null; // Colors to store Vertex colors, if interpolation is requested, else will be kept null
 
 		// Init pixel stats
@@ -204,97 +209,62 @@ public class Rasterizer {
 		// If no interpolation requested -> plain faces. Then:
 		// - calculate normal at Triangle level for shading
 		// - calculate shading color once for all triangle
-		if (!interpolate || to.isTriangleNormal()) {
+		if (!interpolate || t.isTriangleNormal()) {
 			// Calculate normal if not calculated
-			if (to.getNormal()==null) to.calculateNormal();
-			Vector3 normal = to.getNormal();
+			if (t.getNormal()==null) t.calculateNormal();
+			Vector3 normal = t.getNormal();
 			Color shadedCol = computeShadedColor(col, normal);
 			// Then use the shaded color instead for whole triangle
 			col = shadedCol;
+			
 		} else {
-			
-			// As p1, p2 and p3 may be reshuffled and sorted, this is meaningless to calculate the 3 colors at this stage so we postpone
-			// the calculation to later, which increases the complexity and readibility of the algorithm
-			
-			// TODO Further design improvements will allow to simplify this processing by designing direct link between tf and to
-			// (instead of carrying both triangles) e.g. by consolidating at Vertex level both the initial and projected position Vectors
-			// This will also help to reduce the memory usage by duplicating position Vectors only (and not the full Vertices)
+			// Calculate the 3 colors of the 3 Vertex based on their respective normals
+			t.getV1().setShadedCol(computeShadedColor(col, t.getV1().getNormal()));
+			t.getV2().setShadedCol(computeShadedColor(col, t.getV2().getNormal()));
+			t.getV3().setShadedCol(computeShadedColor(col, t.getV3().getNormal()));					
+
 		}
 
-	    // Lets define p1, p2, p3 in order to always have this order on screen p1, p2 & p3
-	    // with p1 always down (thus having the highest possible Y)
-	    // then p2 between p1 & p3 (or same level if p2 and p3 on same ordinate)
+	    // Lets define v1, v2, v3 in order to always have this order on screen v1, v2 & v3 in screen coordinates
+	    // with v1 always down (thus having the highest possible Y)
+	    // then v2 between v1 & v3 (or same level if v2 and v3 on same ordinate)
 		
-		Vector4 p1, p2, p3;
+		//Vector4 p1, p2, p3;
+		Vertex v1, v2, v3;
 
-		p1 = tf.getV1().getPosition();
-		p2 = tf.getV2().getPosition();
-		p3 = tf.getV3().getPosition();
+		v1 = t.getV1();
+		v2 = t.getV2();
+		v3 = t.getV3();
+
 				
-		if (p2.get3DY()<p1.get3DY()) { // p2 lower than p1
-			if (p3.get3DY()<p2.get3DY()) { // p3 lower than p2
-				p1 = tf.getV3().getPosition();
-				p2 = tf.getV2().getPosition();
-				p3 = tf.getV1().getPosition();
-				if (interpolate && !to.isTriangleNormal()) {
-					// Calculate the 3 colors of the 3 Vertex normals
-					c1 = computeShadedColor(col, to.getV3().getNormal());
-					c2 = computeShadedColor(col, to.getV2().getNormal());
-					c3 = computeShadedColor(col, to.getV1().getNormal());					
-				}
+		if (v2.getPos().get3DY()<v1.getPos().get3DY()) { // p2 lower than p1
+			if (v3.getPos().get3DY()<v2.getPos().get3DY()) { // p3 lower than p2
+				v1 = t.getV3();
+				v2 = t.getV2();
+				v3 = t.getV1();
 			} else { // p2 lower than p3
-				if (p3.get3DY()<p1.get3DY()) { // p3 lower than p1
-					p1 = tf.getV2().getPosition();
-					p2 = tf.getV3().getPosition();
-					p3 = tf.getV1().getPosition();
-					if (interpolate && !to.isTriangleNormal()) {
-						// Calculate the 3 colors of the 3 Vertex normals
-						c1 = computeShadedColor(col, to.getV2().getNormal());
-						c2 = computeShadedColor(col, to.getV3().getNormal());
-						c3 = computeShadedColor(col, to.getV1().getNormal());					
-					}
+				if (v3.getPos().get3DY()<v1.getPos().get3DY()) { // p3 lower than p1
+					v1 = t.getV2();
+					v2 = t.getV3();
+					v3 = t.getV1();
 				} else { // p1 higher than p3
-					p1 = tf.getV2().getPosition();
-					p2 = tf.getV1().getPosition();
-					p3 = tf.getV3().getPosition();
-					if (interpolate && !to.isTriangleNormal()) {
-						// Calculate the 3 colors of the 3 Vertex normals
-						c1 = computeShadedColor(col, to.getV2().getNormal());
-						c2 = computeShadedColor(col, to.getV1().getNormal());
-						c3 = computeShadedColor(col, to.getV3().getNormal());					
-					}
+					v1 = t.getV2();
+					v2 = t.getV1();
+					v3 = t.getV3();
 				}
 			}
 		} else { // p1 lower than p2
-			if (p3.get3DY()<p1.get3DY()) { // p3 lower than p1
-				p1 = tf.getV3().getPosition();
-				p2 = tf.getV1().getPosition();
-				p3 = tf.getV2().getPosition();
-				if (interpolate && !to.isTriangleNormal()) {
-					// Calculate the 3 colors of the 3 Vertex normals
-					c1 = computeShadedColor(col, to.getV3().getNormal());
-					c2 = computeShadedColor(col, to.getV1().getNormal());
-					c3 = computeShadedColor(col, to.getV2().getNormal());					
-				}
+			if (v3.getPos().get3DY()<v1.getPos().get3DY()) { // p3 lower than p1
+				v1 = t.getV3();
+				v2 = t.getV1();
+				v3 = t.getV2();
 			} else { // p1 lower than p3
-				if (p3.get3DY()<p2.get3DY()) { // p3 lower than p2
+				if (v3.getPos().get3DY()<v2.getPos().get3DY()) { // p3 lower than p2
 					// No change for p1
-					p2 = tf.getV3().getPosition();
-					p3 = tf.getV2().getPosition();
-					if (interpolate && !to.isTriangleNormal()) {
-						// Calculate the 3 colors of the 3 Vertex normals
-						c1 = computeShadedColor(col, to.getV1().getNormal());
-						c2 = computeShadedColor(col, to.getV3().getNormal());
-						c3 = computeShadedColor(col, to.getV2().getNormal());					
-					}
+					v2 = t.getV3();
+					v3 = t.getV2();
 				} else {
 					// Else keep p1, p2 and p3 as defined
-					if (interpolate && !to.isTriangleNormal()) {
-						// Calculate the 3 colors of the 3 Vertex normals
-						c1 = computeShadedColor(col, to.getV1().getNormal());
-						c2 = computeShadedColor(col, to.getV2().getNormal());
-						c3 = computeShadedColor(col, to.getV3().getNormal());					
-					}
 				}
 			}
 		}
@@ -304,14 +274,14 @@ public class Rasterizer {
 
 	    // http://en.wikipedia.org/wiki/Slope
 	    // Computing slopes
-	    if (yScreen(p2) - yScreen(p1) > 0) {
-	        dP1P2 = (xScreen(p2)-xScreen(p1))/(yScreen(p2)-yScreen(p1));
+	    if (yScreen(v2) - yScreen(v1) > 0) {
+	        dP1P2 = (xScreen(v2)-xScreen(v1))/(yScreen(v2)-yScreen(v1));
 	    } else { // vertical segment, no slope
 	        dP1P2 = 0;
 	    }
 	    
-	    if (yScreen(p3) - yScreen(p1) > 0) {
-	        dP1P3 = (xScreen(p3) - xScreen(p1)) / (yScreen(p3) - yScreen(p1));
+	    if (yScreen(v3) - yScreen(v1) > 0) {
+	        dP1P3 = (xScreen(v3) - xScreen(v1)) / (yScreen(v3) - yScreen(v1));
 	    } else { // vertical segment, no slope
 	        dP1P3 = 0;
 	    }
@@ -331,11 +301,11 @@ public class Rasterizer {
 			// +
 		    // P1
 	    	
-	        for (int y = (int)yScreen(p1); y <= (int)yScreen(p3); y++) {
-	            if (y < yScreen(p2)) {
-	                rasterizeScanLine(y, p1, p3, p1, p2, c1, c3, c1, c2, col, interpolate && !to.isTriangleNormal());
+	        for (int y = (int)yScreen(v1); y <= (int)yScreen(v3); y++) {
+	            if (y < yScreen(v2)) {
+	                rasterizeScanLine(y, v1, v3, v1, v2, col, interpolate && !t.isTriangleNormal());
 	            } else {
-	                rasterizeScanLine(y, p1, p3, p2, p3, c1, c3, c2, c3, col, interpolate && !to.isTriangleNormal());
+	                rasterizeScanLine(y, v1, v3, v2, v3, col, interpolate && !t.isTriangleNormal());
 	            }
 	        }
 
@@ -354,32 +324,32 @@ public class Rasterizer {
 			//        +
 		    //       P1
 	    	
-	        for (int y = (int)yScreen(p1); y <= (int)yScreen(p3); y++) {
-	            if (y < yScreen(p2)) {
-	                rasterizeScanLine(y, p1, p2, p1, p3, c1, c2, c1, c3, col, interpolate && !to.isTriangleNormal());
+	        for (int y = (int)yScreen(v1); y <= (int)yScreen(v3); y++) {
+	            if (y < yScreen(v2)) {
+	                rasterizeScanLine(y, v1, v2, v1, v3, col, interpolate && !t.isTriangleNormal());
 	            } else {
-	                rasterizeScanLine(y, p2, p3, p1, p3, c2, c3, c1, c3, col, interpolate && !to.isTriangleNormal());
+	                rasterizeScanLine(y, v2, v3, v1, v3, col, interpolate && !t.isTriangleNormal());
 	            }
 	        }
 	    }
 		if (Tracer.info) Tracer.traceInfo(this.getClass(), "Rendered pixels for this triangle: "+rendered_pixels+". Discarded: "+discarded_pixels+". Not rendered: "+not_rendered_pixels);
 	}
 	
-	protected void rasterizeScanLine(int y, Vector4 pa, Vector4 pb, Vector4 pc, Vector4 pd, Color ca, Color cb, Color cc, Color cd, Color c, boolean interpolate) {
+	protected void rasterizeScanLine(int y, Vertex va, Vertex vb, Vertex vc, Vertex vd, Color c, boolean interpolate) {
 		
 	    // Thanks to current Y, we can compute the gradient to compute others values like
 	    // the starting X (sx) and ending X (ex) to draw between
 	    // if pa.Y == pb.Y or pc.Y == pd.Y, gradient is forced to 1
 		
-	    float gradient1 = (float)(yScreen(pa) != yScreen(pb) ? (y - yScreen(pa)) / (yScreen(pb) - yScreen(pa)) : 1);
-	    float gradient2 = (float)(yScreen(pc) != yScreen(pd) ? (y - yScreen(pc)) / (yScreen(pd) - yScreen(pc)) : 1);
+	    float gradient1 = (float)(yScreen(va) != yScreen(vb) ? (y - yScreen(va)) / (yScreen(vb) - yScreen(va)) : 1);
+	    float gradient2 = (float)(yScreen(vc) != yScreen(vd) ? (y - yScreen(vc)) / (yScreen(vd) - yScreen(vc)) : 1);
 
-	    int sx = (int)Tools.interpolate(xScreen(pa), xScreen(pb), gradient1);
-	    int ex = (int)Tools.interpolate(xScreen(pc), xScreen(pd), gradient2);
+	    int sx = (int)Tools.interpolate(xScreen(va), xScreen(vb), gradient1);
+	    int ex = (int)Tools.interpolate(xScreen(vc), xScreen(vd), gradient2);
 
 	    // starting Z & ending Z
-	    float z1 = Tools.interpolate((float)pa.get3DZ(), (float)pb.get3DZ(), gradient1);
-	    float z2 = Tools.interpolate((float)pc.get3DZ(), (float)pd.get3DZ(), gradient2);
+	    float z1 = Tools.interpolate((float)va.getProjPos().get3DZ(), (float)vb.getProjPos().get3DZ(), gradient1);
+	    float z2 = Tools.interpolate((float)vc.getProjPos().get3DZ(), (float)vd.getProjPos().get3DZ(), gradient2);
 	    
 	    // drawing a line from left (sx) to right (ex) 
 	    for (int x = sx; x < ex; x++) {
@@ -389,8 +359,8 @@ public class Rasterizer {
 	        // If color interpolation
 	        if (interpolate) {
 	        	Color c1, c2;
-	        	c1 = ColorTools.interpolateColors(ca, cb, gradient1);
-	        	c2 = ColorTools.interpolateColors(cc, cd, gradient2);
+	        	c1 = ColorTools.interpolateColors(va.getShadedCol(), vb.getShadedCol(), gradient1);
+	        	c2 = ColorTools.interpolateColors(vc.getShadedCol(), vd.getShadedCol(), gradient2);
 	        	c = ColorTools.interpolateColors(c1, c2, gradient);
 	        }
 	        drawPoint(x, y, z, c);

--- a/src/com/aventura/engine/Rasterizer.java
+++ b/src/com/aventura/engine/Rasterizer.java
@@ -232,13 +232,13 @@ public class Rasterizer {
 		v2 = t.getV2();
 		v3 = t.getV3();
 
-		if (v2.getPos().get3DY()<v1.getPos().get3DY()) { // p2 lower than p1
-			if (v3.getPos().get3DY()<v2.getPos().get3DY()) { // p3 lower than p2
+		if (v2.getProjPos().get3DY()<v1.getProjPos().get3DY()) { // p2 lower than p1
+			if (v3.getProjPos().get3DY()<v2.getProjPos().get3DY()) { // p3 lower than p2
 				v1 = t.getV3();
 				v2 = t.getV2();
 				v3 = t.getV1();
 			} else { // p2 lower than p3
-				if (v3.getPos().get3DY()<v1.getPos().get3DY()) { // p3 lower than p1
+				if (v3.getProjPos().get3DY()<v1.getProjPos().get3DY()) { // p3 lower than p1
 					v1 = t.getV2();
 					v2 = t.getV3();
 					v3 = t.getV1();
@@ -249,12 +249,12 @@ public class Rasterizer {
 				}
 			}
 		} else { // p1 lower than p2
-			if (v3.getPos().get3DY()<v1.getPos().get3DY()) { // p3 lower than p1
+			if (v3.getProjPos().get3DY()<v1.getProjPos().get3DY()) { // p3 lower than p1
 				v1 = t.getV3();
 				v2 = t.getV1();
 				v3 = t.getV2();
 			} else { // p1 lower than p3
-				if (v3.getPos().get3DY()<v2.getPos().get3DY()) { // p3 lower than p2
+				if (v3.getProjPos().get3DY()<v2.getProjPos().get3DY()) { // p3 lower than p2
 					// No change for p1
 					v2 = t.getV3();
 					v3 = t.getV2();

--- a/src/com/aventura/engine/Rasterizer.java
+++ b/src/com/aventura/engine/Rasterizer.java
@@ -216,27 +216,22 @@ public class Rasterizer {
 			Color shadedCol = computeShadedColor(col, normal);
 			// Then use the shaded color instead for whole triangle
 			col = shadedCol;
-			
 		} else {
 			// Calculate the 3 colors of the 3 Vertex based on their respective normals
 			t.getV1().setShadedCol(computeShadedColor(col, t.getV1().getNormal()));
 			t.getV2().setShadedCol(computeShadedColor(col, t.getV2().getNormal()));
 			t.getV3().setShadedCol(computeShadedColor(col, t.getV3().getNormal()));					
-
 		}
 
 	    // Lets define v1, v2, v3 in order to always have this order on screen v1, v2 & v3 in screen coordinates
 	    // with v1 always down (thus having the highest possible Y)
-	    // then v2 between v1 & v3 (or same level if v2 and v3 on same ordinate)
-		
-		//Vector4 p1, p2, p3;
+	    // then v2 between v1 & v3 (or same level if v2 and v3 on same ordinate)	
 		Vertex v1, v2, v3;
 
 		v1 = t.getV1();
 		v2 = t.getV2();
 		v3 = t.getV3();
 
-				
 		if (v2.getPos().get3DY()<v1.getPos().get3DY()) { // p2 lower than p1
 			if (v3.getPos().get3DY()<v2.getPos().get3DY()) { // p3 lower than p2
 				v1 = t.getV3();
@@ -383,11 +378,13 @@ public class Rasterizer {
 			
 			if (zBuf_x<0 || zBuf_x>=zBuf_width) {
 				if (Tracer.error) Tracer.traceError(this.getClass(), "Invalid zBuffer_x value while drawing points: "+zBuf_x);
+				discarded_pixels++;
 				return;
 			}
 			
 			if (zBuf_y<0 || zBuf_y>=zBuf_height) {
 				if (Tracer.error) Tracer.traceError(this.getClass(), "Invalid zBuffer_y value while drawing points: "+zBuf_y);
+				discarded_pixels++;
 				return;
 			}
 			

--- a/src/com/aventura/engine/Rasterizer.java
+++ b/src/com/aventura/engine/Rasterizer.java
@@ -164,24 +164,24 @@ public class Rasterizer {
 	}
 
 	
-	public void drawVectorFromPosition(Vertex position, Vector3 vector, Color c) {
-		
-		view.setColor(c);
-		drawVectorFromPosition(position, vector);
-	}
+//	public void drawVectorFromPosition(Vertex position, Vector3 vector, Color c) {
+//		
+//		view.setColor(c);
+//		drawVectorFromPosition(position, vector);
+//	}
 
-	public void drawVectorFromPosition(Vertex position, Vector3 vector) {
-		
-		int x1, y1, x2, y2;
-		x1 = (int)(xScreen(position));
-		y1 = (int)(yScreen(position));
-		
-		Vector4 p = position.getPos().plus(vector); 
-		x2 = (int)(xScreen(p));
-		y2 = (int)(yScreen(p));
-
-		view.drawLine(x1, y1, x2, y2);
-	}
+//	public void drawVectorFromPosition(Vertex position, Vector3 vector) {
+//		
+//		int x1, y1, x2, y2;
+//		x1 = (int)(xScreen(position));
+//		y1 = (int)(yScreen(position));
+//		
+//		Vector4 p = position.getPos().plus(vector); 
+//		x2 = (int)(xScreen(p));
+//		y2 = (int)(yScreen(p));
+//
+//		view.drawLine(x1, y1, x2, y2);
+//	}
 	
 	//
 	// End methods for Segment only Rendering

--- a/src/com/aventura/engine/RenderEngine.java
+++ b/src/com/aventura/engine/RenderEngine.java
@@ -224,6 +224,13 @@ public class RenderEngine {
 		Matrix4 model = matrix.times(e.getTransformation());
 		transformation.setModel(model);
 		transformation.computeTransformation(); // Compute the whole ModelView transformation matrix including Camera (view)
+		
+		// TODO NEW TO BE ADDED AND COMPUTED
+		// TRANSFORMATION OF ALL VERTICES OF THE ELEMENT
+		// PRIOR TO TRIANGLE RENDERING
+		// NOW THE TRANSFORMATION IS AT VERTEX LEVEL AND NEEDS TO BE PROCESSED BEFORE RENDERING
+		// THIS IS MORE OPTIMAL AS VERTICES BELONGING TO SEVERAL TRIANGLES ARE ONLY PROJECTED ONCE
+		// THIS REQUIRES TO IMPLEMENT LIST OF VERTICES AT ELEMENT LEVEL
 				
 		// Process each Triangle
 		for (int j=0; j<e.getTriangles().size(); j++) {
@@ -256,44 +263,25 @@ public class RenderEngine {
 	 * Pre-requisite: This assumes that the initialization of ModelView transformation is already done
 	 * 
 	 * @param to the triangle to render
-	 * @param c the color of the Element, can be overiden if color defined (not null) at Triangle level
+	 * @param c the color of the Element, can be overridden if color defined (not null) at Triangle level
 	 * @return false if triangle is outside the View Frustum, else true
 	 */
-	public void render(Triangle to, Color c) {
+	public void render(Triangle t, Color c) {
 		
 		//if (Tracer.function) Tracer.traceFunction(this.getClass(), "Render triangle");
 		
 		// Priority to lowest level -> if color defined at triangle level, then this overrides the color of above (Element) level 
-		Color color = to.getColor();
+		Color color = t.getColor();
 		if (color == null) color = c;
-		
-		// Evolution to fully cope with Model -> World transformation
-		// ==========================================================
-		//
-		// Create temporarily a new triangle that will be the original triangle transformed in World coordinates
-		Triangle ti;
-		
-		// This triangle should however be a complete copy of the original triangle for all attributes of Triangle and Vertices
-		// because this will then (temporarily) replace the original triangle to for all triangle rendering steps
-		ti = transformation.modelToWorld(to);
-		//
-		// Doing so will fix the problem of Element <-> World transformation for shading calculation etc. (as of now, shading
-		// is calculated using to normals but these vectors can be transformed by Element <-> World transformation
-		
-		Triangle tf; // The projected model view triangle in homogeneous coordinates 
-		
-		// Project this Triangle in the View in homogeneous coordinates
-		// This new triangle contains vertices that are transformed
-		tf = transformation.modelToClip(to);
 		
 		// Scissor test for the triangle
 		// If triangle is totally or partially in the View Frustum
 		// Then renderContext its fragments in the View
-		if (isInViewFrustum(tf)) { // Render triangle
+		if (isInViewFrustum(t)) { // Render triangle
 
 			switch (renderContext.rendering_type) {
 			case RenderContext.RENDERING_TYPE_LINE:
-				rasterizer.drawTriangleLines(tf, color);
+				rasterizer.drawTriangleLines(t, color);
 				break;
 			case RenderContext.RENDERING_TYPE_MONOCHROME:
 				//TODO To be implemented
@@ -304,11 +292,11 @@ public class RenderEngine {
 			case RenderContext.RENDERING_TYPE_PLAIN:
 				// Draw triangles with shading full face, no interpolation.
 				// This forces the mode to be normal at Triangle level even if the normals are at Vertex level
-				rasterizer.rasterizeTriangle(tf, ti, color, false);
+				rasterizer.rasterizeTriangle(t, color, false);
 				break;
 			case RenderContext.RENDERING_TYPE_INTERPOLATE:
 				// Draw triangles with shading and interpolation on the triangle face -> Gouraud's Shading
-				rasterizer.rasterizeTriangle(tf, ti, color, true);
+				rasterizer.rasterizeTriangle(t, color, true);
 				break;
 			default:
 				// Invalid rendering type
@@ -317,7 +305,7 @@ public class RenderEngine {
 
 			// If DISPLAY_NORMALS is activated then renderContext normals
 			if (renderContext.displayNormals == RenderContext.DISPLAY_NORMALS_ENABLED) {
-				displayNormalVectors(to);
+				displayNormalVectors(t);
 			}
 			// Count Triangles stats (in view)
 			nbt_in++;
@@ -354,9 +342,9 @@ public class RenderEngine {
 	protected boolean isInViewFrustum(Vertex v) {
 		
 		// Get homogeneous coordinates of the Vertex
-		double x = v.getPosition().get3DX();
-		double y = v.getPosition().get3DY();
-		double z = v.getPosition().get3DZ();
+		double x = v.getPos().get3DX();
+		double y = v.getPos().get3DY();
+		double z = v.getPos().get3DZ();
 		
 		// Need all (homogeneous) coordinates to be within range [-1, 1]
 		if ((x<=1 && x>=-1) && (y<=1 && y>=-1) && (z<=1 && z>=-1))
@@ -376,13 +364,14 @@ public class RenderEngine {
 		Vertex x = new Vertex(1,0,0);
 		Vertex y = new Vertex(0,1,0);
 		Vertex z = new Vertex(0,0,1);
+		transformation.transform(o);
+		transformation.transform(x);
+		transformation.transform(y);
+		transformation.transform(z);
 		// Create 3 unit segments
-		Segment line_x = new Segment(o, x);
-		Segment line_y = new Segment(o, y);
-		Segment line_z = new Segment(o, z);
-		Segment lx = transformation.modelToClip(line_x);
-		Segment ly = transformation.modelToClip(line_y);
-		Segment lz = transformation.modelToClip(line_z);
+		Segment lx = new Segment(o, x);
+		Segment ly = new Segment(o, y);
+		Segment lz = new Segment(o, z);
 		// Draw segments with different colors (x=RED, y=GREEN, z=BLUE) for mnemotechnic
 		rasterizer.drawLine(lx, renderContext.landmarkXColor);
 		rasterizer.drawLine(ly, renderContext.landmarkYColor);
@@ -440,44 +429,43 @@ public class RenderEngine {
 		render(e3, Matrix4.IDENTITY, renderContext.landmarkZColor);
 	}
 	
-	public void displayNormalVectors(Triangle to) {
+	public void displayNormalVectors(Triangle t) {
 		// Caution: in this section, we need to take the original triangle containing the normal and other attributes !!!
 		
-		if (Tracer.info) Tracer.traceInfo(this.getClass(), "Display normals for triangle. Normal of triangle "+to.getNormal());
+		if (Tracer.info) Tracer.traceInfo(this.getClass(), "Display normals for triangle. Normal of triangle "+t.getNormal());
 		
 		// Get the 3 vertices from Triangle
-		Vertex p1 = to.getV1();
-		Vertex p2 = to.getV2();
-		Vertex p3 = to.getV3();
-		Vertex n1, n2, n3;
+		Vertex p1 = t.getV1();
+		Vertex p2 = t.getV2();
+		Vertex p3 = t.getV3();
 		
-		if (to.isTriangleNormal()) { // Normal at Triangle level
-			if (Tracer.info) Tracer.traceInfo(this.getClass(), "Normal at Triangle level. Normal: "+to.getNormal());
+		if (t.isTriangleNormal()) { // Normal at Triangle level
+			if (Tracer.info) Tracer.traceInfo(this.getClass(), "Normal at Triangle level. Normal: "+t.getNormal());
 			// Create 3 vertices corresponding to the end point of the 3 normal vectors
 			// In this case these vertices are calculated from a single normal vector, the one at Triangle level
-			Vertex c = to.getCenter();
-			Vertex n = new Vertex(c.getPosition().plus(to.getNormal()));
+			Vertex c = t.getCenter();
+			Vertex n = new Vertex(c.getPos().plus(t.getNormal()));
+			transformation.transform(n);
 			if (Tracer.info) Tracer.traceInfo(this.getClass(), "Normal display - Center of triangle"+c);
 			if (Tracer.info) Tracer.traceInfo(this.getClass(), "Normal display - Arrow of normal"+n);
-			Segment segment = new Segment(c, n);
-			Segment l = transformation.modelToClip(segment);
-			rasterizer.drawLine(l, renderContext.normalsColor);
+			Segment s = new Segment(c, n);
+			rasterizer.drawLine(s, renderContext.normalsColor);
 			
 		} else { // Normals at Vertex level
+			Vertex n1, n2, n3;
 			if (Tracer.info) Tracer.traceInfo(this.getClass(), "Normal at Vertex level");
 			// Create 3 vertices corresponding to the end point of the 3 normal vectors
-			n1 = new Vertex(p1.getPosition().plus(p1.getNormal()));
-			n2 = new Vertex(p2.getPosition().plus(p2.getNormal()));
-			n3 = new Vertex(p3.getPosition().plus(p3.getNormal()));
+			n1 = new Vertex(p1.getPos().plus(p1.getNormal()));
+			n2 = new Vertex(p2.getPos().plus(p2.getNormal()));
+			n3 = new Vertex(p3.getPos().plus(p3.getNormal()));
+			transformation.transform(n1);
+			transformation.transform(n2);
+			transformation.transform(n3);
 			
 			// Create 3 segments corresponding to normal vectors
-			Segment line1 = new Segment(p1, n1);
-			Segment line2 = new Segment(p2, n2);
-			Segment line3 = new Segment(p3, n3);
-			// Transform the 3 normals
-			Segment l1 = transformation.modelToClip(line1);
-			Segment l2 = transformation.modelToClip(line2);
-			Segment l3 = transformation.modelToClip(line3);
+			Segment l1 = new Segment(p1, n1);
+			Segment l2 = new Segment(p2, n2);
+			Segment l3 = new Segment(p3, n3);
 			
 			// Draw each normal vector starting from their corresponding vertex  
 			rasterizer.drawLine(l1, renderContext.normalsColor);
@@ -492,9 +480,10 @@ public class RenderEngine {
 		transformation.computeTransformation();
 		Vertex v = new Vertex(lighting.getDirectionalLight().getLightVector(null));
 		Vertex o = new Vertex(0,0,0);
-		Segment segment = new Segment(o, v);
-		Segment l = transformation.modelToClip(segment);
-		rasterizer.drawLine(l, renderContext.lightVectorsColor);
+		transformation.transform(v);
+		transformation.transform(o);
+		Segment s = new Segment(o, v);
+		rasterizer.drawLine(s, renderContext.lightVectorsColor);
 	}
 
 

--- a/src/com/aventura/engine/RenderEngine.java
+++ b/src/com/aventura/engine/RenderEngine.java
@@ -231,6 +231,8 @@ public class RenderEngine {
 		// NOW THE TRANSFORMATION IS AT VERTEX LEVEL AND NEEDS TO BE PROCESSED BEFORE RENDERING
 		// THIS IS MORE OPTIMAL AS VERTICES BELONGING TO SEVERAL TRIANGLES ARE ONLY PROJECTED ONCE
 		// THIS REQUIRES TO IMPLEMENT LIST OF VERTICES AT ELEMENT LEVEL
+		
+		// Calculate projection for all vertices of this Element
 		modelView.transformVertices(e);
 				
 		// Process each Triangle
@@ -343,9 +345,9 @@ public class RenderEngine {
 	protected boolean isInViewFrustum(Vertex v) {
 		
 		// Get homogeneous coordinates of the Vertex
-		double x = v.getPos().get3DX();
-		double y = v.getPos().get3DY();
-		double z = v.getPos().get3DZ();
+		double x = v.getProjPos().get3DX();
+		double y = v.getProjPos().get3DY();
+		double z = v.getProjPos().get3DZ();
 		
 		// Need all (homogeneous) coordinates to be within range [-1, 1]
 		if ((x<=1 && x>=-1) && (y<=1 && y>=-1) && (z<=1 && z>=-1))
@@ -445,6 +447,7 @@ public class RenderEngine {
 			// Create 3 vertices corresponding to the end point of the 3 normal vectors
 			// In this case these vertices are calculated from a single normal vector, the one at Triangle level
 			Vertex c = t.getCenter();
+			modelView.transform(c);
 			Vertex n = new Vertex(c.getPos().plus(t.getNormal()));
 			modelView.transform(n);
 			if (Tracer.info) Tracer.traceInfo(this.getClass(), "Normal display - Center of triangle"+c);

--- a/src/com/aventura/math/transform/Rotation.java
+++ b/src/com/aventura/math/transform/Rotation.java
@@ -61,7 +61,7 @@ public class Rotation extends Matrix4 {
 	
 	public Rotation(double a, Vector4 v) {
 		super(Matrix4.IDENTITY);
-		initRotation(a, v.getVector3());
+		initRotation(a, v.V3());
 		if (Tracer.function) Tracer.traceFunction(this.getClass(), "Creation of Rotation matrix:\n");
 	}
 	

--- a/src/com/aventura/math/vector/Vector3.java
+++ b/src/com/aventura/math/vector/Vector3.java
@@ -386,7 +386,7 @@ public class Vector3 {
 	 * Create a new Vector4 from this Vector3 containing 0 as w coordinate
 	 * @return a newly created Vector 4
 	 */
-	public Vector4 getVector4() {
+	public Vector4 V4() {
 		return new Vector4(this);
 	}
 }

--- a/src/com/aventura/math/vector/Vector4.java
+++ b/src/com/aventura/math/vector/Vector4.java
@@ -259,14 +259,6 @@ public class Vector4 {
 	}
 	
 	/**
-	 * Get a new Vector3 representing the 3 first coordinates of this Vector
-	 * @return z
-	 */
-	public Vector3 getVector3() {
-		return new Vector3(this.x, this.y, this.z);
-	}
-
-	/**
 	 * Get a new Vector3 representing the 3 first coordinates of this Vector divided by the 4th coordinate (3D Point)
 	 * @return z
 	 */
@@ -517,6 +509,14 @@ public class Vector4 {
 		this.y = array[1];
 		this.z = array[2];
 		this.w = array[3];
-	}	
+	}
+	
+	/**
+	 * Get a new Vector3 representing the 3 first coordinates of this Vector
+	 * @return z
+	 */
+	public Vector3 V3() {
+		return new Vector3(this);
+	}
 
 }

--- a/src/com/aventura/model/world/Box.java
+++ b/src/com/aventura/model/world/Box.java
@@ -90,14 +90,14 @@ public class Box extends Element {
 		double zh = z_dim/2;
 		
 		// Build the Element: Create Vertices of the Cube: 8 vertices
-		vertices[0][0][0] = new Vertex(new Vector4(-xh, -yh, -zh,  1).plus(position));
-		vertices[0][1][0] = new Vertex(new Vector4(-xh,  yh, -zh,  1).plus(position));
-		vertices[1][1][0] = new Vertex(new Vector4(xh, yh, -zh,  1).plus(position));
-		vertices[1][0][0] = new Vertex(new Vector4(xh, -yh, -zh,  1).plus(position));
-		vertices[0][0][1] = new Vertex(new Vector4(-xh, -yh, zh,  1).plus(position));
-		vertices[0][1][1] = new Vertex(new Vector4(-xh,  yh, zh,  1).plus(position));
-		vertices[1][1][1] = new Vertex(new Vector4(xh, yh, zh,  1).plus(position));
-		vertices[1][0][1] = new Vertex(new Vector4(xh,  -yh, zh,  1).plus(position));
+		vertices[0][0][0] = createVertex(new Vector4(-xh, -yh, -zh,  1).plus(position));
+		vertices[0][1][0] = createVertex(new Vector4(-xh,  yh, -zh,  1).plus(position));
+		vertices[1][1][0] = createVertex(new Vector4(xh, yh, -zh,  1).plus(position));
+		vertices[1][0][0] = createVertex(new Vector4(xh, -yh, -zh,  1).plus(position));
+		vertices[0][0][1] = createVertex(new Vector4(-xh, -yh, zh,  1).plus(position));
+		vertices[0][1][1] = createVertex(new Vector4(-xh,  yh, zh,  1).plus(position));
+		vertices[1][1][1] = createVertex(new Vector4(xh, yh, zh,  1).plus(position));
+		vertices[1][0][1] = createVertex(new Vector4(xh,  -yh, zh,  1).plus(position));
 		
 		// Creates Triangles from Vertices: 6 faces, 2 triangles each
 		Triangle t1 = new Triangle(vertices[0][0][0], vertices[0][1][0], vertices[1][1][0]);

--- a/src/com/aventura/model/world/Cone.java
+++ b/src/com/aventura/model/world/Cone.java
@@ -115,7 +115,7 @@ public class Cone extends Element {
 		// Create summits (same Vertex for all summits)
 		Vector4 summit = new Vector4(0, 0, height/2,  1);
 		for (int i=0; i<half_seg*2; i++) {
-			summits[i] = new Vertex(summit.plus(center));		
+			summits[i] = createVertex(summit.plus(center));		
 		}
 		//summit = new Vertex(new Vector4(0, 0, height/2,  1));
 		
@@ -126,7 +126,7 @@ public class Cone extends Element {
 			double cosa = Math.cos(alpha*i);
 			
 			// Bottom circle of the cylinder
-			vertices[i] = new Vertex(new Vector4(ray*cosa, ray*sina, -height/2, 1).plus(center));
+			vertices[i] = createVertex(new Vector4(ray*cosa, ray*sina, -height/2, 1).plus(center));
 			
 		}
 		

--- a/src/com/aventura/model/world/Cone.java
+++ b/src/com/aventura/model/world/Cone.java
@@ -157,20 +157,20 @@ public class Cone extends Element {
 
 			// For each bottom Vertex, calculate a ray vector that is orthogonal to the slope of the cone
 			// u = OS^OP (O = bottom center, S = summit, P = bottom Vertex)
-			u = (summits[i].getPosition().minus(bottom_center)).times(vertices[i].getPosition().minus(bottom_center));
-			n = (vertices[i].getPosition().minus(summits[i].getPosition())).times(u);
+			u = (summits[i].getPos().minus(bottom_center)).times(vertices[i].getPos().minus(bottom_center));
+			n = (vertices[i].getPos().minus(summits[i].getPos())).times(u);
 			n.normalize();
-			vertices[i].setNormal(n.getVector3());
+			vertices[i].setNormal(n.V3());
 			
 			// For each summit, use the ray vector from top center to the Vertex and normalize it
 			if (i<half_seg*2-1) {
 				//n = (vertices[i+1].getPosition().minus(vertices[i].getPosition())).times(summits[i].getPosition().minus(vertices[i].getPosition()));
-				n = (vertices[i].getPosition().minus(summits[i].getPosition())).times(vertices[i+1].getPosition().minus(summits[i].getPosition()));
+				n = (vertices[i].getPos().minus(summits[i].getPos())).times(vertices[i+1].getPos().minus(summits[i].getPos()));
 			} else { // last vertex -> i+1 = 0
-				n = (vertices[i].getPosition().minus(summits[i].getPosition())).times(vertices[0].getPosition().minus(summits[i].getPosition()));			
+				n = (vertices[i].getPos().minus(summits[i].getPos())).times(vertices[0].getPos().minus(summits[i].getPos()));			
 			}
 			n.normalize();
-			summits[i].setNormal(n.getVector3());
+			summits[i].setNormal(n.V3());
 		}
 		calculateSubNormals();
 	}

--- a/src/com/aventura/model/world/ConeFrustum.java
+++ b/src/com/aventura/model/world/ConeFrustum.java
@@ -192,21 +192,21 @@ public class ConeFrustum extends Element {
 			
 			// For each bottom and top Vertex, calculate a ray vector that is orthogonal to the slope of the cone
 			// u = OS^OP (O = bottom center, S = summit, P = bottom Vertex)
-			u = (summit.getPosition().minus(bottom_center)).times(vertices[i][0].getPosition().minus(bottom_center));
-			n = (vertices[i][0].getPosition().minus(summit.getPosition())).times(u);
+			u = (summit.getPos().minus(bottom_center)).times(vertices[i][0].getPos().minus(bottom_center));
+			n = (vertices[i][0].getPos().minus(summit.getPos())).times(u);
 			n.normalize();
-			vertices[i][0].setNormal(n.getVector3());
-			vertices[i][2].setNormal(n.getVector3());
+			vertices[i][0].setNormal(n.V3());
+			vertices[i][2].setNormal(n.V3());
 			
 			// For each middle Vertex
 			if (i==half_seg*2-1) { // Last one
-				n = vertices[0][2].getPosition().minus(vertices[half_seg*2-1][0].getPosition()).times(vertices[half_seg*2-1][2].getPosition().minus(vertices[0][0].getPosition()));				
+				n = vertices[0][2].getPos().minus(vertices[half_seg*2-1][0].getPos()).times(vertices[half_seg*2-1][2].getPos().minus(vertices[0][0].getPos()));				
 				n.normalize();
 			} else {
-				n = vertices[i+1][2].getPosition().minus(vertices[i][0].getPosition()).times(vertices[i][2].getPosition().minus(vertices[i+1][0].getPosition()));
+				n = vertices[i+1][2].getPos().minus(vertices[i][0].getPos()).times(vertices[i][2].getPos().minus(vertices[i+1][0].getPos()));
 			}
 			n.normalize();
-			vertices[i][1].setNormal(n.getVector3());
+			vertices[i][1].setNormal(n.V3());
 		}
 		calculateSubNormals();
 	}

--- a/src/com/aventura/model/world/ConeFrustum.java
+++ b/src/com/aventura/model/world/ConeFrustum.java
@@ -122,7 +122,7 @@ public class ConeFrustum extends Element {
 		// Create vertices
 		
 		// Create summits (same Vertex for all summits)
-		summit = new Vertex(new Vector4(0, 0, cone_height/2,  1).plus(center));
+		summit = createVertex(new Vector4(0, 0, cone_height/2,  1).plus(center));
 		
 		// Create circle vertices
 		for (int i=0; i<half_seg*2; i++) {
@@ -131,17 +131,17 @@ public class ConeFrustum extends Element {
 			double cosa = Math.cos(alpha*i);
 			
 			// Bottom circle of the cone
-			vertices[i][0] = new Vertex(new Vector4(ray*cosa, ray*sina, -cone_height/2, 1).plus(center));
+			vertices[i][0] = createVertex(new Vector4(ray*cosa, ray*sina, -cone_height/2, 1).plus(center));
 			
 			// Top circle of the cone
 			double ratio = (cone_height - frustum_height)/cone_height;
-			vertices[i][2] = new Vertex(new Vector4(ratio*ray*cosa, ratio*ray*sina, (frustum_height-(cone_height/2)), 1).plus(center));
+			vertices[i][2] = createVertex(new Vector4(ratio*ray*cosa, ratio*ray*sina, (frustum_height-(cone_height/2)), 1).plus(center));
 			
 			// Middle circle of the cylinder
 			double sinb = Math.sin(alpha*i+beta);
 			double cosb = Math.cos(alpha*i+beta);
 			ratio = (cone_height - mid_height)/cone_height;
-			vertices[i][1] = new Vertex(new Vector4(ratio*ray*cosb, ratio*ray*sinb, (mid_height-(cone_height/2)), 1).plus(center));
+			vertices[i][1] = createVertex(new Vector4(ratio*ray*cosb, ratio*ray*sinb, (mid_height-(cone_height/2)), 1).plus(center));
 		}
 		
 		// Create Triangles

--- a/src/com/aventura/model/world/ConeSummit.java
+++ b/src/com/aventura/model/world/ConeSummit.java
@@ -113,7 +113,7 @@ public class ConeSummit extends Element {
 		// Create vertices
 		
 		// Create summits (same Vertex for all summits)
-		summit = new Vertex(new Vector4(0, 0, height/2,  1).plus(center));
+		summit = createVertex(new Vector4(0, 0, height/2,  1).plus(center));
 		
 		// Create bottom vertices
 		for (int i=0; i<half_seg*2; i++) {
@@ -122,7 +122,7 @@ public class ConeSummit extends Element {
 			double cosa = Math.cos(alpha*i);
 			
 			// Bottom circle of the cylinder
-			vertices[i] = new Vertex(new Vector4(ray*cosa, ray*sina, -height/2, 1).plus(center));
+			vertices[i] = createVertex(new Vector4(ray*cosa, ray*sina, -height/2, 1).plus(center));
 			
 		}
 		

--- a/src/com/aventura/model/world/ConeSummit.java
+++ b/src/com/aventura/model/world/ConeSummit.java
@@ -150,17 +150,17 @@ public class ConeSummit extends Element {
 		
 		// Create normal of summit
 		n = new Vector4(Vector4.Z_AXIS);
-		summit.setNormal(n.getVector3());
+		summit.setNormal(n.V3());
 			
 		// Create normals of vertices
 		for (int i=0; i<half_seg*2; i++) {
 
 			// For each bottom Vertex, calculate a ray vector that is orthogonal to the slope of the cone
 			// u = OS^OP (O = bottom center, S = summit, P = bottom Vertex)
-			u = (summit.getPosition().minus(bottom_center)).times(vertices[i].getPosition().minus(bottom_center));
-			n = (vertices[i].getPosition().minus(summit.getPosition())).times(u);
+			u = (summit.getPos().minus(bottom_center)).times(vertices[i].getPos().minus(bottom_center));
+			n = (vertices[i].getPos().minus(summit.getPos())).times(u);
 			n.normalize();
-			vertices[i].setNormal(n.getVector3());
+			vertices[i].setNormal(n.V3());
 		}
 		calculateSubNormals();
 	}

--- a/src/com/aventura/model/world/Cylinder.java
+++ b/src/com/aventura/model/world/Cylinder.java
@@ -152,11 +152,11 @@ public class Cylinder extends Element {
 		// Create normals of vertices
 		for (int i=0; i<half_seg*2; i++) {
 			// For each bottom Vertex, use the ray vector from bottom center to the Vertex and normalize it 
-			n = vertices[i][0].getPosition().minus(bottom_center);
+			n = vertices[i][0].getPos().minus(bottom_center);
 			n.normalize();
-			vertices[i][0].setNormal(n.getVector3());
+			vertices[i][0].setNormal(n.V3());
 			// Same normal vector can be used for the corresponding top Vertex
-			vertices[i][1].setNormal(n.getVector3());
+			vertices[i][1].setNormal(n.V3());
 		}
 		
 		calculateSubNormals();

--- a/src/com/aventura/model/world/Cylinder.java
+++ b/src/com/aventura/model/world/Cylinder.java
@@ -118,10 +118,10 @@ public class Cylinder extends Element {
 			double cosa = Math.cos(alpha*i);
 			
 			// Bottom circle of the cylinder
-			vertices[i][0] = new Vertex(new Vector4(ray*cosa, ray*sina, -height/2, 1).plus(center));
+			vertices[i][0] = createVertex(new Vector4(ray*cosa, ray*sina, -height/2, 1).plus(center));
 			
 			// Top circle of the cylinder
-			vertices[i][1] = new Vertex(new Vector4(ray*cosa, ray*sina, height/2, 1).plus(center));
+			vertices[i][1] = createVertex(new Vector4(ray*cosa, ray*sina, height/2, 1).plus(center));
 		}
 		
 		// Create Triangles

--- a/src/com/aventura/model/world/Element.java
+++ b/src/com/aventura/model/world/Element.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 
 import com.aventura.math.transform.Transformable;
 import com.aventura.math.vector.Matrix4;
+import com.aventura.math.vector.Vector4;
 
 /**
  * ------------------------------------------------------------------------------ 
@@ -119,7 +120,7 @@ public class Element implements Transformable {
 	
 	protected ArrayList<Element> subelements; // To create a hierarchy of elements - not necessarily used
 	protected ArrayList<Triangle> triangles;  // Triangles related to this element
-	//protected ArrayList<Vertex> vertices;     // Vertices of this element (also referenced by the triangles)
+	protected ArrayList<Vertex> vertices;     // Vertices of this element (also referenced by the triangles)
 	
 	protected Matrix4 transform;  // Element to World Transformation Matrix (Model Matrix)
 	protected Color color; // Color of the element unless specified at Triangle or Vertex level (lowest level priority)
@@ -127,6 +128,7 @@ public class Element implements Transformable {
 	public Element() {
 		super();
 		triangles = new ArrayList<Triangle>();
+		vertices = new ArrayList<Vertex>();
 		transform = Matrix4.IDENTITY; // By default
 	}
 	
@@ -138,9 +140,15 @@ public class Element implements Transformable {
 		}
 	}
 	
-//	public void addVertex(Vertex v) {
-//		//TODO To be implemented
-//	}
+	public void addVertex(Vertex v) {
+		this.vertices.add(v);
+	}
+	
+	public Vertex createVertex(Vector4 v4) {
+		Vertex v = new Vertex(v4);
+		addVertex(v);
+		return v;
+	}
 	
 	public ArrayList<Element> getSubElements() {
 		return subelements;
@@ -176,6 +184,18 @@ public class Element implements Transformable {
 	
 	public int getNbOfTriangles() {
 		return triangles.size();
+	}
+
+	public ArrayList<Vertex> getVertices() {
+		return vertices;
+	}
+	
+	public Vertex getVertex(int i) {
+		return vertices.get(i);
+	}
+	
+	public int getNbOfVertices() {
+		return vertices.size();
 	}
 
 	@Override

--- a/src/com/aventura/model/world/Sphere.java
+++ b/src/com/aventura/model/world/Sphere.java
@@ -115,8 +115,8 @@ public class Sphere extends Element {
 		double alpha = Math.PI/half_seg;
 		
 		// Create Vertices
-		northPole = new Vertex(new Vector4(0, 0, ray,  1));
-		southPole = new Vertex(new Vector4(0, 0, -ray,  1));
+		northPole = createVertex(new Vector4(0, 0, ray,  1));
+		southPole = createVertex(new Vector4(0, 0, -ray,  1));
 		
 		for (int i=0; i<half_seg*2; i++) {
 			for (int j=0; j<(half_seg-1); j++) {
@@ -124,7 +124,7 @@ public class Sphere extends Element {
 				double cosa = Math.cos(alpha*i);
 				double sinb = Math.sin(alpha*(j+1));
 				double cosb = Math.cos(alpha*(j+1));
-				vertices[i][j] = new Vertex(new Vector4(ray*cosa*sinb, ray*sina*sinb, ray*cosb, 1).plus(center));
+				vertices[i][j] = createVertex(new Vector4(ray*cosa*sinb, ray*sina*sinb, ray*cosb, 1).plus(center));
 			}
 		}
 

--- a/src/com/aventura/model/world/Sphere.java
+++ b/src/com/aventura/model/world/Sphere.java
@@ -85,7 +85,7 @@ public class Sphere extends Element {
 		subelements = null;
 		this.ray = ray;
 		this.half_seg = half_seg;
-		this.center = center.getVector4();
+		this.center = center.V4();
 		createSphere();
 	}
 	
@@ -176,9 +176,9 @@ public class Sphere extends Element {
 		for (int i=0; i<half_seg*2; i++) {
 			for (int j=0; j<(half_seg-1); j++) {
 				// For each Vertex, use the ray vector passing through the Vertex and normalize it 
-				Vector4 n = vertices[i][j].getPosition().minus(center);
+				Vector4 n = vertices[i][j].getPos().minus(center);
 				n.normalize();
-				vertices[i][j].setNormal(n.getVector3());
+				vertices[i][j].setNormal(n.V3());
 			}
 		}
 		calculateSubNormals();

--- a/src/com/aventura/model/world/Torus.java
+++ b/src/com/aventura/model/world/Torus.java
@@ -128,7 +128,7 @@ public class Torus extends Element {
 
 
 				// Each vertice
-				vertices[i][j] = new Vertex(new Vector4((torus_ray+pipe_ray*cosb)*cosa, (torus_ray+pipe_ray*cosb)*sina, pipe_ray*sinb, 1).plus(center));
+				vertices[i][j] = createVertex(new Vector4((torus_ray+pipe_ray*cosb)*cosa, (torus_ray+pipe_ray*cosb)*sina, pipe_ray*sinb, 1).plus(center));
 			}
 		}
 		

--- a/src/com/aventura/model/world/Torus.java
+++ b/src/com/aventura/model/world/Torus.java
@@ -180,9 +180,9 @@ public class Torus extends Element {
 		for (int i=0; i<half_circ*2; i++) {
 			for (int j=0; j<half_seg*2; j++) {
 				// For each bottom Vertex, use the ray vector from bottom center to the Vertex and normalize it 
-				n = vertices[i][j].getPosition().minus(centers[i]);
+				n = vertices[i][j].getPos().minus(centers[i]);
 				n.normalize();
-				vertices[i][j].setNormal(n.getVector3());
+				vertices[i][j].setNormal(n.V3());
 			}
 		}
 		

--- a/src/com/aventura/model/world/Trellis.java
+++ b/src/com/aventura/model/world/Trellis.java
@@ -194,7 +194,7 @@ public class Trellis extends Element {
 		// Create Vertices
 		for (int i=0; i<=nx; i++) {
 			for (int j=0; j<=ny; j++) {
-				vertices[i][j] = new Vertex(new Vector4(i*width/nx, j*length/ny, 0, 1).plus(position));
+				vertices[i][j] = createVertex(new Vector4(i*width/nx, j*length/ny, 0, 1).plus(position));
 			}
 		}
 	}
@@ -210,7 +210,7 @@ public class Trellis extends Element {
 		// Create Vertices
 		for (int i=0; i<=nx; i++) {
 			for (int j=0; j<=ny; j++) {
-				vertices[i][j] = new Vertex(new Vector4(i*width/nx, j*length/ny, array[i][j], 1).plus(position));
+				vertices[i][j] = createVertex(new Vector4(i*width/nx, j*length/ny, array[i][j], 1).plus(position));
 			}
 		}
 	}

--- a/src/com/aventura/model/world/Trellis.java
+++ b/src/com/aventura/model/world/Trellis.java
@@ -267,34 +267,34 @@ public class Trellis extends Element {
 				Vector4 xa, xb, ya, yb, xavg, yavg;
 				
 				if (i>0) {
-					xa = vertices[i-1][j].getPosition();
+					xa = vertices[i-1][j].getPos();
 				} else {
-					xa = vertices[i][j].getPosition(); // When on the side: take the vertex itself to calculate the average
+					xa = vertices[i][j].getPos(); // When on the side: take the vertex itself to calculate the average
 				}
 				if (i<nx) {
-					xb = vertices[i+1][j].getPosition();
+					xb = vertices[i+1][j].getPos();
 				} else {
-					xb = vertices[i][j].getPosition(); // When on the side: take the vertex itself to calculate the average
+					xb = vertices[i][j].getPos(); // When on the side: take the vertex itself to calculate the average
 				}
 				xavg = xb.minus(xa);
 				
 				// The second one is aligned on the Y axis
 				if (j>0) {
-					ya = vertices[i][j-1].getPosition();
+					ya = vertices[i][j-1].getPos();
 				} else {
-					ya = vertices[i][j].getPosition(); // When on the side: take the vertex itself to calculate the average
+					ya = vertices[i][j].getPos(); // When on the side: take the vertex itself to calculate the average
 				}
 				if (j<ny) {
-					yb = vertices[i][j+1].getPosition();
+					yb = vertices[i][j+1].getPos();
 				} else {
-					yb = vertices[i][j].getPosition(); // When on the side: take the vertex itself to calculate the average
+					yb = vertices[i][j].getPos(); // When on the side: take the vertex itself to calculate the average
 				}
 				yavg = yb.minus(ya);
 								
 				// The normal vector is the cross product of both vectors.
 				Vector4 normal = xavg.times(yavg);
 				// Need to be normalized
-				vertices[i][j].setNormal(normal.normalize().getVector3());
+				vertices[i][j].setNormal(normal.normalize().V3());
 			}
 		}
 		calculateSubNormals();

--- a/src/com/aventura/model/world/Triangle.java
+++ b/src/com/aventura/model/world/Triangle.java
@@ -102,7 +102,7 @@ public class Triangle {
 	 * @return
 	 */
 	public Vertex getCenter() {
-		Vector4 p = (v1.getPosition().plus(v2.getPosition()).plus(v3.getPosition())).times((double)1/3);
+		Vector4 p = (v1.getPos().plus(v2.getPos()).plus(v3.getPos())).times((double)1/3);
 		Vertex c = new Vertex(p);
 		return c;
 	}
@@ -128,7 +128,7 @@ public class Triangle {
 	}
 	
 	public void setNormal(Vector4 n) {
-		this.normal = n.getVector3();
+		this.normal = n.V3();
 	}
 	
 	public void setColor(Color c) {
@@ -145,10 +145,10 @@ public class Triangle {
 	 */
 	public void calculateNormal() {
 		//P = V1V2 as a Vector3
-		Vector3 p = (v2.position.minus(v1.position)).getVector3();
+		Vector3 p = (v2.position.minus(v1.position)).V3();
 
 		//P = V1V3 as a Vector3
-		Vector3 q = (v3.position.minus(v1.position)).getVector3();
+		Vector3 q = (v3.position.minus(v1.position)).V3();
 
 		// Calculate the cross product
 		normal = p.times(q);

--- a/src/com/aventura/model/world/Vertex.java
+++ b/src/com/aventura/model/world/Vertex.java
@@ -41,9 +41,9 @@ public class Vertex {
 	
 	// Projected Geometry
 	protected Vector4 wld_position = null; // Position of this Vertex in World reference (Model to World projection)
-	protected Vector4 prj_position = null; // Position of this Vertex in Homogeneous coordinates (Model to Clip projection)
-	protected Vector3 wld_normal = null;
-	protected Vector3 prj_normal = null;
+	protected Vector4 prj_position = null; // Position of this Vertex in Homogeneous (clip) coordinates (Model to Clip projection)
+	protected Vector3 wld_normal = null; // Normal in World coordinates
+	protected Vector3 prj_normal = null; // Normal in Homogeneous (clip) coordinates
 	
 	// Physical characteristic
 	protected Vector2 texture = null; // Relative position of this Vertex in the texture plane

--- a/src/com/aventura/model/world/Vertex.java
+++ b/src/com/aventura/model/world/Vertex.java
@@ -40,13 +40,18 @@ public class Vertex {
 	protected Vector3 normal = null; // Normal of this Vertex, this is context specific and can be kept null if normal at Triangle level
 	
 	// Projected Geometry
-	protected Vector4 wld_position = null;
-	protected Vector4 prj_position = null;
+	protected Vector4 wld_position = null; // Position of this Vertex in World reference (Model to World projection)
+	protected Vector4 prj_position = null; // Position of this Vertex in Homogeneous coordinates (Model to Clip projection)
+	protected Vector3 wld_normal = null;
+	protected Vector3 prj_normal = null;
 	
 	// Physical characteristic
 	protected Vector2 texture = null; // Relative position of this Vertex in the texture plane
 	protected Color color = null; // color of this Vertex, if null the Element's color (or World's color) is used. Lowest level priority.
 	protected int material; // To be defined, a specific class may be needed for a complex material representation
+	
+	// Shading
+	protected Color shadedCol = null; // Gouraud's shading at this Vertex
 	
 	// Reflectivity
 	// TODO
@@ -85,43 +90,76 @@ public class Vertex {
 
 	public Vertex(Vector4 p, Vector4 n) {
 		position = p;
-		normal = n.getVector3();
+		normal = n.V3();
 	}
 
 	public String toString() {
 		return "Position: "+position;
 	}
 	
-	public void setPosition(Vector4 p) {
+	public void setPos(Vector4 p) {
 		position = p;
 	}
 	
-	public Vector4 getPosition() {
+	public Vector4 getPos() {
 		return position;
 	}
 	
-	public Vector4 getWorldPosition() {
+	public void setWorldPos(Vector4 p) {
+		wld_position = p;
+	}
+	
+	public Vector4 getWorldPos() {
 		return wld_position;
 	}
 	
-	public Vector4 getProjectedPosition() {
+	public void setProjPos(Vector4 p) {
+		prj_position = p;
+	}
+	
+	public Vector4 getProjPos() {
 		return prj_position;
+	}
+	
+	public void setNormal(Vector3 n) {
+		normal = n;
 	}
 	
 	public Vector3 getNormal() {
 		return normal;
 	}
-	
-	public Vector4 getNormalV4() {
-		return new Vector4(normal);
+		
+	public void setWorldNormal(Vector3 n) {
+		wld_normal = n;
 	}
 	
+	public Vector3 getWorldNormal() {
+		return wld_normal;
+	}
+	
+	public void setProjNormal(Vector3 n) {
+		prj_normal = n;
+	}
+	public Vector3 getProjNormal() {
+		return prj_normal;
+	}
+		
+
+		
 	public void setColor(Color c) {
 		this.color = c;
 	}
 	
 	public Color getColor() {
 		return color;
+	}
+	
+	public void setShadedCol(Color c) {
+		this.shadedCol = c;
+	}
+	
+	public Color getShadedCol() {
+		return shadedCol;
 	}
 	
 	/**
@@ -134,10 +172,6 @@ public class Vertex {
 		for (int i=0; i<setOfVertices.length; i++) {
 			// TODO
 		}
-	}
-
-	public void setNormal(Vector3 n) {
-		normal = n;
 	}
 
 }

--- a/src/com/aventura/model/world/Vertex.java
+++ b/src/com/aventura/model/world/Vertex.java
@@ -35,9 +35,13 @@ import com.aventura.math.vector.*;
  */
 public class Vertex {
 	
-	// Geometry
+	// Original Geometry
 	protected Vector4 position = null; // Coordinates of the Vertex. Vector4 as this is a Point (not vector only) in space.
 	protected Vector3 normal = null; // Normal of this Vertex, this is context specific and can be kept null if normal at Triangle level
+	
+	// Projected Geometry
+	protected Vector4 wld_position = null;
+	protected Vector4 prj_position = null;
 	
 	// Physical characteristic
 	protected Vector2 texture = null; // Relative position of this Vertex in the texture plane
@@ -94,6 +98,14 @@ public class Vertex {
 	
 	public Vector4 getPosition() {
 		return position;
+	}
+	
+	public Vector4 getWorldPosition() {
+		return wld_position;
+	}
+	
+	public Vector4 getProjectedPosition() {
+		return prj_position;
 	}
 	
 	public Vector3 getNormal() {

--- a/src/com/aventura/test/TestAventura12.java
+++ b/src/com/aventura/test/TestAventura12.java
@@ -174,7 +174,7 @@ public class TestAventura12 {
 		GraphicContext context = new GraphicContext(1.5, 0.9, 1, 100, GraphicContext.PERSPECTIVE_TYPE_FRUSTUM, 1000);
 		View view = test.createView(context);
 
-		RenderContext rContext = new RenderContext(RenderContext.RENDER_STANDARD_INTERPOLATE);
+		RenderContext rContext = new RenderContext(RenderContext.RENDER_STANDARD_INTERPOLATE_WITH_LANDMARKS);
 		
 		RenderEngine renderer = new RenderEngine(world, lighting, camera, rContext, context);
 		renderer.setView(view);

--- a/src/com/aventura/test/TestRasterizer2.java
+++ b/src/com/aventura/test/TestRasterizer2.java
@@ -81,6 +81,9 @@ public class TestRasterizer2 {
 		Vertex v1 = new Vertex(new Vector4(1,0,0,1));
 		Vertex v2 = new Vertex(new Vector4(0,1,0,1));
 		Vertex v3 = new Vertex(new Vector4(0,0,1,1));
+		e.addVertex(v1);
+		e.addVertex(v2);
+		e.addVertex(v3);
 		Triangle t1 = new Triangle(v1, v2, v3);
 		t1.setColor(Color.ORANGE);
 		e.addTriangle(t1);
@@ -88,6 +91,9 @@ public class TestRasterizer2 {
 		Vertex v4 = new Vertex(new Vector4(0,0,0,1));
 		Vertex v5 = new Vertex(new Vector4(1,1,1,1));
 		Vertex v6 = new Vertex(new Vector4(1,1,0,1));
+		e.addVertex(v4);
+		e.addVertex(v5);
+		e.addVertex(v6);
 		Triangle t2 = new Triangle(v4, v5, v6);
 		t2.setColor(Color.MAGENTA);
 		e.addTriangle(t2);
@@ -95,6 +101,9 @@ public class TestRasterizer2 {
 		Vertex v7 = new Vertex(new Vector4(0,0,0,1));
 		Vertex v8 = new Vertex(new Vector4(0,2,0.5,1));
 		Vertex v9 = new Vertex(new Vector4(2,0,0.5,1));
+		e.addVertex(v7);
+		e.addVertex(v8);
+		e.addVertex(v9);
 		Triangle t3 = new Triangle(v7, v8, v9);
 		t3.setColor(Color.GREEN);
 		e.addTriangle(t3);

--- a/src/com/aventura/test/TestRasterizer5.java
+++ b/src/com/aventura/test/TestRasterizer5.java
@@ -83,6 +83,9 @@ public class TestRasterizer5 {
 		Vertex v1 = new Vertex(new Vector4(1,0,0,1));
 		Vertex v2 = new Vertex(new Vector4(0,1,0,1));
 		Vertex v3 = new Vertex(new Vector4(0,0,1,1));
+		e.addVertex(v1);
+		e.addVertex(v2);
+		e.addVertex(v3);		
 		Triangle t1 = new Triangle(v1, v2, v3);
 		t1.setColor(Color.ORANGE);
 		e.addTriangle(t1);
@@ -90,6 +93,9 @@ public class TestRasterizer5 {
 		Vertex v4 = new Vertex(new Vector4(0,0,0,1));
 		Vertex v5 = new Vertex(new Vector4(1,1,1,1));
 		Vertex v6 = new Vertex(new Vector4(1,1,0,1));
+		e.addVertex(v4);
+		e.addVertex(v5);
+		e.addVertex(v6);		
 		Triangle t2 = new Triangle(v4, v5, v6);
 		t2.setColor(Color.MAGENTA);
 		e.addTriangle(t2);
@@ -97,6 +103,9 @@ public class TestRasterizer5 {
 		Vertex v7 = new Vertex(new Vector4(0,0,0,1));
 		Vertex v8 = new Vertex(new Vector4(0,2,0.5,1));
 		Vertex v9 = new Vertex(new Vector4(2,0,0.5,1));
+		e.addVertex(v7);
+		e.addVertex(v8);
+		e.addVertex(v9);		
 		Triangle t3 = new Triangle(v7, v8, v9);
 		t3.setColor(Color.GREEN);
 		e.addTriangle(t3);


### PR DESCRIPTION
Vertex based projection:
- Now Vertex contains all necessary information about projection(s) Model to World and Model to Clip
- It is no more needed to have different triangles or different Vertices to represent the initial and transformed Vertices
- Main external change is that the Element owns Vertices list (in addition to Triangle list) which requires, for each Vertex of an Element to call Element.addVertex(). This is implemented for each pre-built Element.
- This refactoring brings lots of simplification in the RenderEngine, ModelView and Rasterizer classes.

Still to be verified / done:
- Are the Normal projections needed in the Vertex class ?
- Full test coverage?
- Commenting the Rasterizer class (very poor) to explain xScreen/yScreen, drawLines, scanLines etc...