### PR TITLE
Fix bug in Cylinder calling subnormals calculation in the

### DIFF
--- a/src/com/aventura/model/world/shape/Cylinder.java
+++ b/src/com/aventura/model/world/shape/Cylinder.java
@@ -126,6 +126,6 @@ public class Cylinder extends Element {
 			rectangleMesh.getVertex(i,1).setNormal(n);
 		}
 		
-		calculateSubNormals();
+		//calculateSubNormals();
 	}
 }


### PR DESCRIPTION
calculateNormals() method.
Only visible with hierarchical elements.