### PR TITLE
Fix regression introduced by computing normals in transformation methods

### DIFF
--- a/src/com/aventura/model/world/shape/Element.java
+++ b/src/com/aventura/model/world/shape/Element.java
@@ -327,7 +327,7 @@ public class Element implements Transformable, Shape {
 	@Override
 	public void setTransformation(Matrix4 transformation) {
 		this.transform = transformation;
-		this.calculateNormals();
+		//this.calculateNormals();
 	}
 
 	@Override
@@ -335,7 +335,7 @@ public class Element implements Transformable, Shape {
 		// TODO Auto-generated method stub
 		//this.transform.timesEquals(transformation);
 		this.transform = transformation.times(this.transform);
-		this.calculateNormals();
+		//this.calculateNormals();
 	}
 
 	@Override


### PR DESCRIPTION
(this.calculateNormals();) in set and combine Transformation methods of
Element.
This is wrong way to support scaling. The right way will be to use
inverse ModelView Matrix. To be implemented.