### PR TITLE
Fix bug in PointLight calculation - now using getWorldPos instead of getPos

### DIFF
--- a/src/com/aventura/engine/Rasterizer.java
+++ b/src/com/aventura/engine/Rasterizer.java
@@ -240,7 +240,7 @@ public class Rasterizer {
 		// - calculate shading color once for all triangle
 		if (!interpolate || t.isTriangleNormal()) {
 			Vector3 normal = t.getWorldNormal();
-			shadedCol = computeShadedColor(surfCol, t.getCenter().getPos(), normal, t.isRectoVerso());
+			shadedCol = computeShadedColor(surfCol, t.getCenterWorldPos(), normal, t.isRectoVerso());
 			//TODO Specular reflection with plain faces.
 			
 		} else {
@@ -259,9 +259,9 @@ public class Rasterizer {
 			viewer3.normalize();
 			
 			// Calculate the 3 colors of the 3 vertices based on their respective normals and direction of the viewer
-			v1.setShadedCol(computeShadedColor(surfCol, v1.getPos(), v1.getWorldNormal(), t.isRectoVerso()));
-			v2.setShadedCol(computeShadedColor(surfCol, v2.getPos(), v2.getWorldNormal(), t.isRectoVerso()));
-			v3.setShadedCol(computeShadedColor(surfCol, v3.getPos(), v3.getWorldNormal(), t.isRectoVerso()));					
+			v1.setShadedCol(computeShadedColor(surfCol, v1.getWorldPos(), v1.getWorldNormal(), t.isRectoVerso()));
+			v2.setShadedCol(computeShadedColor(surfCol, v2.getWorldPos(), v2.getWorldNormal(), t.isRectoVerso()));
+			v3.setShadedCol(computeShadedColor(surfCol, v3.getWorldPos(), v3.getWorldNormal(), t.isRectoVerso()));					
 
 			// Calculate the 3 colors of the 3 vertices based on their respective normals and direction of the viewer
 			if (lighting.hasSpecular()) {

--- a/src/com/aventura/model/world/triangle/Triangle.java
+++ b/src/com/aventura/model/world/triangle/Triangle.java
@@ -206,6 +206,10 @@ public class Triangle {
 		return c;
 	}
 	
+	public Vector4 getCenterWorldPos() {
+		return (v1.getWorldPos().plus(v2.getWorldPos()).plus(v3.getWorldPos())).times((float)1/3);
+	}
+	
 	/**
 	 * Set the first Vertex of this Triangle
 	 */

--- a/src/com/aventura/test/TestLighting1.java
+++ b/src/com/aventura/test/TestLighting1.java
@@ -25,6 +25,7 @@ import com.aventura.model.texture.Texture;
 import com.aventura.model.world.World;
 import com.aventura.model.world.shape.Box;
 import com.aventura.model.world.shape.Cube;
+import com.aventura.model.world.shape.Sphere;
 import com.aventura.model.world.shape.Trellis;
 import com.aventura.view.SwingView;
 import com.aventura.view.GUIView;
@@ -109,19 +110,23 @@ public class TestLighting1 {
 		System.out.println("********* Creating World");
 		
 		Texture tex1 = new Texture("resources/texture/texture_bricks_204x204.jpg");
-		//Texture tex2 = new Texture("resources/texture/texture_blueground_204x204.jpg");
+		Texture tex3 = new Texture("resources/texture/texture_blueground_204x204.jpg");
 		Texture tex2 = new Texture("resources/texture/texture_woodfloor_160x160.jpg");
 		
 		World world = new World();
 		Trellis trellis = new Trellis(8, 8, 20, 20, tex2);
-		Cube cube = new Cube(1,tex1);
+		Cube cube = new Cube(1, tex1);
+		Sphere sphere = new Sphere (0.5f ,10 , tex3);
 		// cube.setColor(new Color(200,50,50));
 		// Translate cube on top of trellis
-		Translation t1 = new Translation(new Vector3(0, 0, 0.5f));
+		Translation t1 = new Translation(new Vector3(1.5f, 0, 0.5f));
+		Translation t2 = new Translation(new Vector3(-1.5f, 0, 0.5f));
 		cube.setTransformation(t1);
+		sphere.setTransformation(t2);
 
 		world.addElement(trellis);
 		world.addElement(cube);
+		world.addElement(sphere);
 		
 		System.out.println("********* Calculating normals");
 		world.generate();
@@ -129,7 +134,7 @@ public class TestLighting1 {
 
 		//DirectionalLight dl = new DirectionalLight(new Vector3(0,1,2));
 		AmbientLight al = new AmbientLight(0.05f);
-		PointLight pl = new PointLight(new Vector4(-2,-2,1,1),8);
+		PointLight pl = new PointLight(new Vector4(3,3,1.2f,1),8);
 		//Lighting light = new Lighting(dl, al);
 		Lighting light = new Lighting(al);
 		light.addPointLight(pl);
@@ -146,14 +151,15 @@ public class TestLighting1 {
 		renderer.setView(gUIView);
 		renderer.render();
 
-//		System.out.println("********* Rendering...");
-//		int nb_images = 180;
-//		for (int i=0; i<=3*nb_images; i++) {
-//			Rotation r = new Rotation((float)Math.PI*2*(float)i/(float)nb_images, Vector3.Z_AXIS);
-//			trellis.setTransformation(r);
-//			cube.combineTransformation(r);
-//			renderer.render();
-//		}
+		System.out.println("********* Rendering...");
+		int nb_images = 180;
+		for (int i=0; i<=3*nb_images; i++) {
+			Rotation r = new Rotation((float)Math.PI*2*(float)i/(float)nb_images, Vector3.Z_AXIS);
+			trellis.setTransformation(r);
+			cube.setTransformation(r.times(t1));
+			sphere.setTransformation(r.times(t2));
+			renderer.render();
+		}
 
 		System.out.println("********* ENDING APPLICATION *********");
 	}


### PR DESCRIPTION
Implementation for distance calculation was using getPos instead of getWorldPos for calculation of PointLight distance when calculating shaded color in Rasterizer / PointLight.
The problem was visible only when using Transformations (e.g. Translations or Rotations) because getWoldPos differs from getPos in those cases.
Tested usint TestLighting1.