### PR TITLE
Start Rasterizer refactoring to allow Shadowing processing

### DIFF
--- a/src/com/aventura/math/vector/Matrix3.java
+++ b/src/com/aventura/math/vector/Matrix3.java
@@ -114,11 +114,11 @@ public class Matrix3 {
 	@Override
 	public String toString() {
 		String s = "[";
-		for (int i=0; i<Constants.SIZE_3-1; i++) {
-			s = s + Arrays.toString(array[i]);
-			s = s+"\n";
+		s = s + Arrays.toString(array[0]) + "\n";
+		for (int i=1; i<Constants.SIZE_3-1; i++) {
+			s = s + " " + Arrays.toString(array[i]) + "\n";
 		}
-		s = s + Arrays.toString(array[Constants.SIZE_3-1])+"]";
+		s = s + " " + Arrays.toString(array[Constants.SIZE_3-1])+"]";
 		return s;
 	}
 

--- a/src/com/aventura/math/vector/Matrix4.java
+++ b/src/com/aventura/math/vector/Matrix4.java
@@ -101,11 +101,11 @@ public class Matrix4 {
 	@Override
 	public String toString() {
 		String s = "[";
-		for (int i=0; i<Constants.SIZE_4-1; i++) {
-			s = s + Arrays.toString(array[i]);
-			s = s+"\n";
+		s = s + Arrays.toString(array[0]) + "\n";
+		for (int i=1; i<Constants.SIZE_4-1; i++) {
+			s = s + " " + Arrays.toString(array[i]) + "\n";
 		}
-		s = s + Arrays.toString(array[Constants.SIZE_4-1])+"]";
+		s = s + " " + Arrays.toString(array[Constants.SIZE_4-1])+"]";
 		return s;
 	}
 	

--- a/src/com/aventura/test/TestRasterizer1.java
+++ b/src/com/aventura/test/TestRasterizer1.java
@@ -45,7 +45,7 @@ public class TestRasterizer1 {
 		
 		System.out.println("GraphicContext: "+graphic);
 		
-		Rasterizer rasterizer = new Rasterizer(graphic);
+		Rasterizer rasterizer = new Rasterizer(null, graphic, null);
 		
 		rasterizer.initZBuffer();
 


### PR DESCRIPTION
The need is to calculate ShadowMap vectors for each Vertex and for each Light. The goal is to perform similar interpolation than Texture mapping but for each Light in the scanline rasterization.
This meed new parameters to be passed to the scanline rasterization method.
At same time the refactoring should allow multiple light's shading calculaion at pixel level (not blending the lights at vertex level).

Some clean-up.