### PR TITLE
Fix bug in OrthographicPerspective constructor.

### DIFF
--- a/src/com/aventura/engine/RenderEngine.java
+++ b/src/com/aventura/engine/RenderEngine.java
@@ -235,7 +235,7 @@ public class RenderEngine {
 					if (Tracer.info) Tracer.traceInfo(this.getClass(), "Shadowing Light #" + i + " : "+shadowingLights.get(i));
 
 					// Initiate the Shading by calculating the light(s) camera/projection matrix(ces)
-					shadowingLights.get(i).initShadowing(perspectiveContext.getPerspective(), camera, gUIView.getViewWidth());
+					shadowingLights.get(i).initShadowing(perspectiveContext.getPerspective(), camera, gUIView.getViewWidth(), world);
 					
 					// Generate the shadow map
 					// TODO optimization : build a world2 containing only the Elements that can cast shadows by using bouncing algorithm then generate shadow map for this world2

--- a/src/com/aventura/model/camera/Camera.java
+++ b/src/com/aventura/model/camera/Camera.java
@@ -67,6 +67,19 @@ public class Camera {
 		lookAt = new LookAt(e,p,u);
 	}
 	
+	/**
+	 * 
+	 * Construction of Camera's LookAt Matrix based on Vector4 only (fwd and up)
+	 * Useful for Camera light
+	 * 
+	 * @param f the fwd vector
+	 * @param u the Up vector for the World to leverage for the Camera
+	 */
+	public Camera(Vector4 f, Vector4 u) {
+		if (Tracer.function) Tracer.traceFunction(this.getClass(), "Creating Camera with vectors f: "+ f +" u: "+u);
+		lookAt = new LookAt(f,u);
+	}
+
 	public void updateCamera(Vector4 e, Vector4 p, Vector4 u) {
 		if (Tracer.function) Tracer.traceFunction(this.getClass(), "Updating Camera with vectors e: "+e+" p: "+p+" u: "+u);
 		eye = e;

--- a/src/com/aventura/model/light/ShadowingLight.java
+++ b/src/com/aventura/model/light/ShadowingLight.java
@@ -66,7 +66,8 @@ public abstract class ShadowingLight extends Light {
 	public static final int SHADOWING_BOX_ELEMENT = 3; // Use any Element's max dimensions to calculate the Light's view box
 	public static final int SHADOWING_BOX_SPECIFIC = 4; // Use a specific box to calculate the Light's view box
 
-	protected int shadowingBox_type = SHADOWING_BOX_VIEWFRUSTUM; // Is Default
+	//protected int shadowingBox_type = SHADOWING_BOX_VIEWFRUSTUM; // Is Default
+	protected int shadowingBox_type = SHADOWING_BOX_WORLD; // Is Default
 	
 	// Fields related to Shadow generation
 	protected Camera camera_light; // The corresponding "camera" from Light View's perspective

--- a/src/com/aventura/model/perspective/OrthographicPerspective.java
+++ b/src/com/aventura/model/perspective/OrthographicPerspective.java
@@ -48,7 +48,7 @@ public class OrthographicPerspective extends Perspective {
 		
 	}
 
-	public OrthographicPerspective(float top, float bottom, float right, float left, float far, float near) {
+	public OrthographicPerspective(float left, float right, float bottom, float top, float near, float far) {
 		super(top, bottom, right, left, far, near);
 		
 		this.projection = new OrthographicProjection(left , right, bottom, top, near, far);

--- a/src/com/aventura/test/TestShadowMapRasterization.java
+++ b/src/com/aventura/test/TestShadowMapRasterization.java
@@ -103,7 +103,7 @@ public class TestShadowMapRasterization {
 		Tracer.function = true;
 		
 		// Camera
-		Vector4 eye = new Vector4(8,-5,5,1);
+		Vector4 eye = new Vector4(0,-5,1,1);
 		Vector4 poi = new Vector4(0,0,0,1);
 		Camera camera = new Camera(eye, poi, Vector4.Z_AXIS);		
 				
@@ -138,8 +138,8 @@ public class TestShadowMapRasterization {
 		System.out.println(sphere);
 
 		//DirectionalLight dl = new DirectionalLight(new Vector3(0,1,2));
-		AmbientLight al = new AmbientLight(0.05f);
-		DirectionalLight dl = new DirectionalLight(new Vector3(3,3,0));
+		AmbientLight al = new AmbientLight(0.25f);
+		DirectionalLight dl = new DirectionalLight(new Vector3(3,0,0));
 		Lighting light = new Lighting(dl, al);
 		//Lighting light = new Lighting(al);
 		//light.setDirectionalLight(dl);


### PR DESCRIPTION
Constructor with left, right, bottom, top, near, far parameters: was called in wrong order. Only impacts the Orthographic projection creation for Directional Light camera/perspective calculation.