### PR TITLE
Fix color calculation in Rasterizer. Change Copyright to 2025.

### DIFF
--- a/src/com/aventura/context/PerspectiveContext.java
+++ b/src/com/aventura/context/PerspectiveContext.java
@@ -9,7 +9,7 @@ import com.aventura.tools.tracing.Tracer;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/context/RenderContext.java
+++ b/src/com/aventura/context/RenderContext.java
@@ -6,7 +6,7 @@ import java.awt.Color;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/demo/AventuraDemo.java
+++ b/src/com/aventura/demo/AventuraDemo.java
@@ -39,7 +39,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/demo/EarthAndMoon.java
+++ b/src/com/aventura/demo/EarthAndMoon.java
@@ -29,7 +29,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/demo/FractalLandscape_MouseMoving.java
+++ b/src/com/aventura/demo/FractalLandscape_MouseMoving.java
@@ -34,7 +34,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/demo/KeyFrame.java
+++ b/src/com/aventura/demo/KeyFrame.java
@@ -9,7 +9,7 @@ import javax.swing.JFrame;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/demo/MovingCamera.java
+++ b/src/com/aventura/demo/MovingCamera.java
@@ -37,7 +37,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/engine/ModelViewProjection.java
+++ b/src/com/aventura/engine/ModelViewProjection.java
@@ -14,7 +14,7 @@ import com.aventura.tools.tracing.Tracer;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -187,7 +187,7 @@ public class ModelViewProjection {
 	 * @param v the provided Vertex
 	 * @param normals boolean should be true if normals should be calculated, false otherwise (Shadowing)
 	 */
-	public void transform(Vertex v, boolean normals) {
+	public void transformVertex(Vertex v, boolean normals) {
 		// Calculate the coordinates in Clip space (full transformation) and store results in Vertex's related field
 		v.setProjPos(full.times(v.getPos()));
 		// Also calculate only the coordinates of the Vertex in World coordinates for geometry calculation (e.g. bounding boxes etc.)
@@ -209,7 +209,7 @@ public class ModelViewProjection {
 	 * @param v the provided Vertex
 	 * @return the projected Vector4 without Vertex transformation
 	 */
-	public Vector4 project(Vertex v) {
+	public Vector4 projectVertex(Vertex v) {
 		return full.times(v.getPos());
 	}
 	
@@ -222,7 +222,7 @@ public class ModelViewProjection {
 	public void transformElement(Element e, boolean normals) {
 		// Loop on all vertices of the Element and transform each of them
 		for (int i=0; i<e.getNbVertices(); i++) {
-			transform(e.getVertex(i), normals);
+			transformVertex(e.getVertex(i), normals);
 		}
 	}
 		

--- a/src/com/aventura/engine/RenderEngine.java
+++ b/src/com/aventura/engine/RenderEngine.java
@@ -29,7 +29,7 @@ import com.aventura.view.MapView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -490,10 +490,10 @@ public class RenderEngine {
 		Vertex x = new Vertex(1,0,0);
 		Vertex y = new Vertex(0,1,0);
 		Vertex z = new Vertex(0,0,1);
-		modelViewProjection.transform(o, true);
-		modelViewProjection.transform(x, true);
-		modelViewProjection.transform(y, true);
-		modelViewProjection.transform(z, true);
+		modelViewProjection.transformVertex(o, true);
+		modelViewProjection.transformVertex(x, true);
+		modelViewProjection.transformVertex(y, true);
+		modelViewProjection.transformVertex(z, true);
 		// Create 3 unit segments
 		Segment lx = new Segment(o, x);
 		Segment ly = new Segment(o, y);
@@ -563,8 +563,8 @@ public class RenderEngine {
 			// In this case the vertices are calculated from a single normal vector, the one at Triangle level
 			Vertex c = t.getCenter();
 			Vertex n = new Vertex(c.getPos().plus(t.getNormal())); // Before transformation -> using position and normals not yet transformed
-			modelViewProjection.transform(c, true);
-			modelViewProjection.transform(n, true);
+			modelViewProjection.transformVertex(c, true);
+			modelViewProjection.transformVertex(n, true);
 			if (Tracer.info) Tracer.traceInfo(this.getClass(), "Normal display - Center of triangle"+c);
 			if (Tracer.info) Tracer.traceInfo(this.getClass(), "Normal display - Arrow of normal"+n);
 			Segment s = new Segment(c, n);
@@ -583,9 +583,9 @@ public class RenderEngine {
 			n1 = new Vertex(p1.getPos().plus(p1.getNormal())); // Before transformation -> using position and normals not yet transformed
 			n2 = new Vertex(p2.getPos().plus(p2.getNormal())); // Before transformation -> using position and normals not yet transformed
 			n3 = new Vertex(p3.getPos().plus(p3.getNormal())); // Before transformation -> using position and normals not yet transformed
-			modelViewProjection.transform(n1, true);
-			modelViewProjection.transform(n2, true);
-			modelViewProjection.transform(n3, true);
+			modelViewProjection.transformVertex(n1, true);
+			modelViewProjection.transformVertex(n2, true);
+			modelViewProjection.transformVertex(n3, true);
 			
 			// Create 3 segments corresponding to normal vectors
 			Segment l1 = new Segment(p1, n1);
@@ -606,8 +606,8 @@ public class RenderEngine {
 		modelViewProjection.calculateMVPMatrix();
 		Vertex v = new Vertex(lighting.getDirectionalLight().getLightVectorAtPoint(null));
 		Vertex o = new Vertex(0,0,0);
-		modelViewProjection.transform(v, true);
-		modelViewProjection.transform(o, true);
+		modelViewProjection.transformVertex(v, true);
+		modelViewProjection.transformVertex(o, true);
 		Segment s = new Segment(o, v);
 		rasterizer.drawLine(s, renderContext.lightVectorsColor);
 	}

--- a/src/com/aventura/math/Constants.java
+++ b/src/com/aventura/math/Constants.java
@@ -4,7 +4,7 @@ package com.aventura.math;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/projection/FrustumProjection.java
+++ b/src/com/aventura/math/projection/FrustumProjection.java
@@ -6,7 +6,7 @@ import com.aventura.tools.tracing.Tracer;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/projection/OrthographicProjection.java
+++ b/src/com/aventura/math/projection/OrthographicProjection.java
@@ -6,7 +6,7 @@ import com.aventura.tools.tracing.Tracer;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/projection/Projection.java
+++ b/src/com/aventura/math/projection/Projection.java
@@ -6,7 +6,7 @@ import com.aventura.math.vector.Matrix4;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/tools/BoundingBox4.java
+++ b/src/com/aventura/math/tools/BoundingBox4.java
@@ -9,7 +9,7 @@ import com.aventura.math.vector.Vector4;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/tools/MathTools.java
+++ b/src/com/aventura/math/tools/MathTools.java
@@ -6,7 +6,7 @@ import com.aventura.math.Constants;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/transform/NotARotationException.java
+++ b/src/com/aventura/math/transform/NotARotationException.java
@@ -2,8 +2,42 @@ package com.aventura.math.transform;
 
 import com.aventura.math.vector.Vector3DException;
 
+/**
+ * ------------------------------------------------------------------------------ 
+ * MIT License
+ * 
+ * Copyright (c) 2016-2025 Olivier BARRY
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * ------------------------------------------------------------------------------ 
+ *
+ * 
+ * @author Olivier BARRY
+ */
+
 public class NotARotationException extends Vector3DException {
 	
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
 	public NotARotationException() {
 		// TODO Auto-generated constructor stub
 	}

--- a/src/com/aventura/math/transform/Rotation.java
+++ b/src/com/aventura/math/transform/Rotation.java
@@ -12,7 +12,7 @@ import com.aventura.tools.tracing.Tracer;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/transform/Scaling.java
+++ b/src/com/aventura/math/transform/Scaling.java
@@ -7,7 +7,7 @@ import com.aventura.tools.tracing.Tracer;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/transform/Transformable.java
+++ b/src/com/aventura/math/transform/Transformable.java
@@ -6,7 +6,7 @@ import com.aventura.math.vector.Matrix4;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/transform/Transformation.java
+++ b/src/com/aventura/math/transform/Transformation.java
@@ -8,7 +8,7 @@ import com.aventura.tools.tracing.Tracer;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/transform/Translation.java
+++ b/src/com/aventura/math/transform/Translation.java
@@ -10,7 +10,7 @@ import com.aventura.math.vector.Vector3;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,6 +39,7 @@ import com.aventura.math.vector.Vector3;
  * @author Olivier BARRY
  * @date May 2014
  */
+
 public class Translation extends Matrix4 {
 	
 	/**

--- a/src/com/aventura/math/transform/WrongAxisException.java
+++ b/src/com/aventura/math/transform/WrongAxisException.java
@@ -2,7 +2,41 @@ package com.aventura.math.transform;
 
 import com.aventura.math.vector.Vector3DException;
 
+/**
+ * ------------------------------------------------------------------------------ 
+ * MIT License
+ * 
+ * Copyright (c) 2016-2025 Olivier BARRY
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * ------------------------------------------------------------------------------ 
+ *
+ * 
+ * @author Olivier BARRY
+ */
+
 public class WrongAxisException extends Vector3DException {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
 
 	public WrongAxisException() {
 		// TODO Auto-generated constructor stub

--- a/src/com/aventura/math/vector/GeometryTools.java
+++ b/src/com/aventura/math/vector/GeometryTools.java
@@ -6,7 +6,7 @@ import com.aventura.math.Constants;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/vector/IndiceOutOfBoundException.java
+++ b/src/com/aventura/math/vector/IndiceOutOfBoundException.java
@@ -4,7 +4,7 @@ package com.aventura.math.vector;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/vector/Matrix3.java
+++ b/src/com/aventura/math/vector/Matrix3.java
@@ -9,7 +9,7 @@ import com.aventura.tools.tracing.Tracer;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/vector/Matrix4.java
+++ b/src/com/aventura/math/vector/Matrix4.java
@@ -9,7 +9,7 @@ import com.aventura.tools.tracing.Tracer;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/vector/MatrixArrayWrongSizeException.java
+++ b/src/com/aventura/math/vector/MatrixArrayWrongSizeException.java
@@ -4,7 +4,7 @@ package com.aventura.math.vector;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/vector/NotInvertibleMatrixException.java
+++ b/src/com/aventura/math/vector/NotInvertibleMatrixException.java
@@ -5,7 +5,7 @@ package com.aventura.math.vector;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/vector/Tools.java
+++ b/src/com/aventura/math/vector/Tools.java
@@ -5,7 +5,7 @@ package com.aventura.math.vector;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/vector/Vector2.java
+++ b/src/com/aventura/math/vector/Vector2.java
@@ -6,7 +6,7 @@ import com.aventura.math.tools.MathTools;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/vector/Vector3.java
+++ b/src/com/aventura/math/vector/Vector3.java
@@ -9,7 +9,7 @@ import com.aventura.tools.tracing.Tracer;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/vector/Vector3DException.java
+++ b/src/com/aventura/math/vector/Vector3DException.java
@@ -4,7 +4,7 @@ package com.aventura.math.vector;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/vector/Vector4.java
+++ b/src/com/aventura/math/vector/Vector4.java
@@ -8,7 +8,7 @@ import com.aventura.tools.tracing.Tracer;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/math/vector/VectorArrayWrongSizeException.java
+++ b/src/com/aventura/math/vector/VectorArrayWrongSizeException.java
@@ -4,7 +4,7 @@ package com.aventura.math.vector;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/camera/Camera.java
+++ b/src/com/aventura/model/camera/Camera.java
@@ -8,7 +8,7 @@ import com.aventura.tools.tracing.Tracer;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/camera/LookAt.java
+++ b/src/com/aventura/model/camera/LookAt.java
@@ -10,7 +10,7 @@ import com.aventura.tools.tracing.Tracer;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/camera/TestCamera.java
+++ b/src/com/aventura/model/camera/TestCamera.java
@@ -13,7 +13,7 @@ import com.aventura.math.vector.Vector4;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/light/AmbientLight.java
+++ b/src/com/aventura/model/light/AmbientLight.java
@@ -10,7 +10,7 @@ import com.aventura.tools.color.ColorTools;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/light/DirectionalLight.java
+++ b/src/com/aventura/model/light/DirectionalLight.java
@@ -19,7 +19,7 @@ import com.aventura.tools.tracing.Tracer;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/light/Light.java
+++ b/src/com/aventura/model/light/Light.java
@@ -8,7 +8,7 @@ import com.aventura.math.vector.Vector4;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/light/Lighting.java
+++ b/src/com/aventura/model/light/Lighting.java
@@ -9,7 +9,7 @@ import com.aventura.tools.tracing.Tracer;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/light/PointLight.java
+++ b/src/com/aventura/model/light/PointLight.java
@@ -12,7 +12,7 @@ import com.aventura.model.world.World;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/light/ShadowingLight.java
+++ b/src/com/aventura/model/light/ShadowingLight.java
@@ -20,7 +20,7 @@ import com.aventura.view.MapView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/light/SpotLight.java
+++ b/src/com/aventura/model/light/SpotLight.java
@@ -13,7 +13,7 @@ import com.aventura.model.world.World;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/perspective/FrustumPerspective.java
+++ b/src/com/aventura/model/perspective/FrustumPerspective.java
@@ -9,7 +9,7 @@ import com.aventura.tools.tracing.Tracer;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/perspective/OrthographicPerspective.java
+++ b/src/com/aventura/model/perspective/OrthographicPerspective.java
@@ -8,7 +8,7 @@ import com.aventura.model.camera.Camera;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/perspective/Perspective.java
+++ b/src/com/aventura/model/perspective/Perspective.java
@@ -8,7 +8,7 @@ import com.aventura.model.camera.Camera;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/texture/Texture.java
+++ b/src/com/aventura/model/texture/Texture.java
@@ -14,7 +14,7 @@ import com.aventura.tools.tracing.Tracer;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/Element.java
+++ b/src/com/aventura/model/world/Element.java
@@ -15,7 +15,7 @@ import com.aventura.model.world.triangle.Triangle;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/Vertex.java
+++ b/src/com/aventura/model/world/Vertex.java
@@ -7,7 +7,7 @@ import com.aventura.math.vector.*;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/World.java
+++ b/src/com/aventura/model/world/World.java
@@ -11,7 +11,7 @@ import com.aventura.tools.tracing.Tracer;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/WrongArraySizeException.java
+++ b/src/com/aventura/model/world/WrongArraySizeException.java
@@ -4,7 +4,7 @@ package com.aventura.model.world;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/shape/Box.java
+++ b/src/com/aventura/model/world/shape/Box.java
@@ -12,7 +12,7 @@ import com.aventura.model.world.triangle.RectangleMesh;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/shape/ClosedCone.java
+++ b/src/com/aventura/model/world/shape/ClosedCone.java
@@ -11,7 +11,7 @@ import com.aventura.model.world.Element;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/shape/ClosedCylinder.java
+++ b/src/com/aventura/model/world/shape/ClosedCylinder.java
@@ -11,7 +11,7 @@ import com.aventura.model.world.Element;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/shape/Cone.java
+++ b/src/com/aventura/model/world/shape/Cone.java
@@ -11,7 +11,7 @@ import com.aventura.model.world.triangle.FanMesh;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/shape/ConeFrustum.java
+++ b/src/com/aventura/model/world/shape/ConeFrustum.java
@@ -11,7 +11,7 @@ import com.aventura.model.world.triangle.FullMesh;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/shape/Cube.java
+++ b/src/com/aventura/model/world/shape/Cube.java
@@ -6,7 +6,7 @@ import com.aventura.model.texture.Texture;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/shape/Cylinder.java
+++ b/src/com/aventura/model/world/shape/Cylinder.java
@@ -10,7 +10,7 @@ import com.aventura.model.world.triangle.RectangleMesh;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/shape/Disc.java
+++ b/src/com/aventura/model/world/shape/Disc.java
@@ -9,7 +9,7 @@ import com.aventura.model.world.triangle.CircularMesh;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/shape/Generable.java
+++ b/src/com/aventura/model/world/shape/Generable.java
@@ -4,7 +4,7 @@ package com.aventura.model.world.shape;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/shape/Pyramid.java
+++ b/src/com/aventura/model/world/shape/Pyramid.java
@@ -13,7 +13,7 @@ import com.aventura.model.world.triangle.RectangleMesh;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/shape/Segment.java
+++ b/src/com/aventura/model/world/shape/Segment.java
@@ -7,7 +7,7 @@ import com.aventura.model.world.Vertex;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/shape/Shape.java
+++ b/src/com/aventura/model/world/shape/Shape.java
@@ -9,7 +9,7 @@ import com.aventura.model.world.Element;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/shape/Sphere.java
+++ b/src/com/aventura/model/world/shape/Sphere.java
@@ -9,7 +9,7 @@ import com.aventura.model.world.triangle.RectangleMesh;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/shape/Torus.java
+++ b/src/com/aventura/model/world/shape/Torus.java
@@ -9,7 +9,7 @@ import com.aventura.model.world.triangle.RectangleMesh;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/shape/Trellis.java
+++ b/src/com/aventura/model/world/shape/Trellis.java
@@ -10,7 +10,7 @@ import com.aventura.model.world.triangle.RectangleMesh;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/triangle/CircularMesh.java
+++ b/src/com/aventura/model/world/triangle/CircularMesh.java
@@ -9,7 +9,7 @@ import com.aventura.model.world.Vertex;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/triangle/FanMesh.java
+++ b/src/com/aventura/model/world/triangle/FanMesh.java
@@ -10,7 +10,7 @@ import com.aventura.model.world.Vertex;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/triangle/FullMesh.java
+++ b/src/com/aventura/model/world/triangle/FullMesh.java
@@ -9,7 +9,7 @@ import com.aventura.model.world.Vertex;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/triangle/Mesh.java
+++ b/src/com/aventura/model/world/triangle/Mesh.java
@@ -10,7 +10,7 @@ import com.aventura.model.world.Element;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/triangle/RectangleMesh.java
+++ b/src/com/aventura/model/world/triangle/RectangleMesh.java
@@ -9,7 +9,7 @@ import com.aventura.model.world.Vertex;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/model/world/triangle/Triangle.java
+++ b/src/com/aventura/model/world/triangle/Triangle.java
@@ -11,7 +11,7 @@ import com.aventura.model.world.Vertex;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/Test3ElementsRotation.java
+++ b/src/com/aventura/test/Test3ElementsRotation.java
@@ -32,7 +32,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/Test3StonesRotation.java
+++ b/src/com/aventura/test/Test3StonesRotation.java
@@ -31,7 +31,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestAventura1.java
+++ b/src/com/aventura/test/TestAventura1.java
@@ -31,7 +31,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestAventura11.java
+++ b/src/com/aventura/test/TestAventura11.java
@@ -29,7 +29,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestAventura2.java
+++ b/src/com/aventura/test/TestAventura2.java
@@ -28,7 +28,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestAventura2bis.java
+++ b/src/com/aventura/test/TestAventura2bis.java
@@ -24,7 +24,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestAventura3.java
+++ b/src/com/aventura/test/TestAventura3.java
@@ -26,7 +26,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestAventura6.java
+++ b/src/com/aventura/test/TestAventura6.java
@@ -24,7 +24,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestAventura7.java
+++ b/src/com/aventura/test/TestAventura7.java
@@ -24,7 +24,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestAventura8.java
+++ b/src/com/aventura/test/TestAventura8.java
@@ -25,7 +25,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestBoxRotation.java
+++ b/src/com/aventura/test/TestBoxRotation.java
@@ -28,7 +28,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestBoxTexture.java
+++ b/src/com/aventura/test/TestBoxTexture.java
@@ -29,7 +29,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestClosedConeTexture.java
+++ b/src/com/aventura/test/TestClosedConeTexture.java
@@ -30,7 +30,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestClosedCylinderTexture.java
+++ b/src/com/aventura/test/TestClosedCylinderTexture.java
@@ -30,7 +30,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestConeFrustum.java
+++ b/src/com/aventura/test/TestConeFrustum.java
@@ -27,7 +27,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestConeFrustumTexture.java
+++ b/src/com/aventura/test/TestConeFrustumTexture.java
@@ -29,7 +29,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestConeTexture.java
+++ b/src/com/aventura/test/TestConeTexture.java
@@ -30,7 +30,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestCubeRotationTexture.java
+++ b/src/com/aventura/test/TestCubeRotationTexture.java
@@ -30,7 +30,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestCylinderTexture.java
+++ b/src/com/aventura/test/TestCylinderTexture.java
@@ -28,7 +28,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestDiscTexture.java
+++ b/src/com/aventura/test/TestDiscTexture.java
@@ -29,7 +29,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestDrawView.java
+++ b/src/com/aventura/test/TestDrawView.java
@@ -29,7 +29,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestFanMesh1.java
+++ b/src/com/aventura/test/TestFanMesh1.java
@@ -30,7 +30,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestFanMesh2.java
+++ b/src/com/aventura/test/TestFanMesh2.java
@@ -30,7 +30,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestFanMesh3.java
+++ b/src/com/aventura/test/TestFanMesh3.java
@@ -30,7 +30,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestFullMesh1.java
+++ b/src/com/aventura/test/TestFullMesh1.java
@@ -30,7 +30,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestFullMesh2.java
+++ b/src/com/aventura/test/TestFullMesh2.java
@@ -30,7 +30,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestFullMesh3.java
+++ b/src/com/aventura/test/TestFullMesh3.java
@@ -30,7 +30,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestLandMarkLines.java
+++ b/src/com/aventura/test/TestLandMarkLines.java
@@ -28,7 +28,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestLighting1.java
+++ b/src/com/aventura/test/TestLighting1.java
@@ -32,7 +32,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestLighting2.java
+++ b/src/com/aventura/test/TestLighting2.java
@@ -32,7 +32,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestLightingSpecular.java
+++ b/src/com/aventura/test/TestLightingSpecular.java
@@ -31,7 +31,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestMapViewForZBuffer.java
+++ b/src/com/aventura/test/TestMapViewForZBuffer.java
@@ -34,7 +34,7 @@ import com.aventura.view.MapView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestMultiBoxTexture.java
+++ b/src/com/aventura/test/TestMultiBoxTexture.java
@@ -30,7 +30,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestMultiElements.java
+++ b/src/com/aventura/test/TestMultiElements.java
@@ -35,7 +35,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestMultiElementsInterpolate.java
+++ b/src/com/aventura/test/TestMultiElementsInterpolate.java
@@ -36,7 +36,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestMultiElementsTexture.java
+++ b/src/com/aventura/test/TestMultiElementsTexture.java
@@ -39,7 +39,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestMultiElementsTextureOrtho.java
+++ b/src/com/aventura/test/TestMultiElementsTextureOrtho.java
@@ -37,7 +37,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestPyramidTexture.java
+++ b/src/com/aventura/test/TestPyramidTexture.java
@@ -29,7 +29,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestPyramidTextureAndColor.java
+++ b/src/com/aventura/test/TestPyramidTextureAndColor.java
@@ -29,7 +29,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestRasterizer1.java
+++ b/src/com/aventura/test/TestRasterizer1.java
@@ -8,7 +8,7 @@ import com.aventura.tools.tracing.Tracer;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestRasterizer11.java
+++ b/src/com/aventura/test/TestRasterizer11.java
@@ -28,7 +28,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestRasterizer12.java
+++ b/src/com/aventura/test/TestRasterizer12.java
@@ -28,7 +28,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestRasterizer13.java
+++ b/src/com/aventura/test/TestRasterizer13.java
@@ -32,7 +32,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestRasterizer14.java
+++ b/src/com/aventura/test/TestRasterizer14.java
@@ -31,7 +31,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestRasterizer15.java
+++ b/src/com/aventura/test/TestRasterizer15.java
@@ -31,7 +31,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestRasterizer2.java
+++ b/src/com/aventura/test/TestRasterizer2.java
@@ -27,7 +27,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestRasterizer3.java
+++ b/src/com/aventura/test/TestRasterizer3.java
@@ -27,7 +27,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestRasterizer5.java
+++ b/src/com/aventura/test/TestRasterizer5.java
@@ -28,7 +28,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestRasterizer7.java
+++ b/src/com/aventura/test/TestRasterizer7.java
@@ -26,7 +26,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestScaling.java
+++ b/src/com/aventura/test/TestScaling.java
@@ -30,7 +30,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestScaling2.java
+++ b/src/com/aventura/test/TestScaling2.java
@@ -30,7 +30,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestShadowMapRasterization.java
+++ b/src/com/aventura/test/TestShadowMapRasterization.java
@@ -34,7 +34,7 @@ import com.aventura.view.MapView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestSphereSpecularReflection.java
+++ b/src/com/aventura/test/TestSphereSpecularReflection.java
@@ -27,7 +27,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestSphereTexture.java
+++ b/src/com/aventura/test/TestSphereTexture.java
@@ -29,7 +29,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestSphereTexture3.java
+++ b/src/com/aventura/test/TestSphereTexture3.java
@@ -28,7 +28,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestTexture.java
+++ b/src/com/aventura/test/TestTexture.java
@@ -17,7 +17,7 @@ import com.aventura.model.texture.Texture;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestTorusTexture.java
+++ b/src/com/aventura/test/TestTorusTexture.java
@@ -30,7 +30,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestTrellis.java
+++ b/src/com/aventura/test/TestTrellis.java
@@ -23,7 +23,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestTrellis2.java
+++ b/src/com/aventura/test/TestTrellis2.java
@@ -24,7 +24,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestTrellisTexture.java
+++ b/src/com/aventura/test/TestTrellisTexture.java
@@ -30,7 +30,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestTwoAttachedRings.java
+++ b/src/com/aventura/test/TestTwoAttachedRings.java
@@ -29,7 +29,7 @@ import com.aventura.view.GUIView;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestView.java
+++ b/src/com/aventura/test/TestView.java
@@ -17,7 +17,7 @@ import com.aventura.view.GUIView;
 * ------------------------------------------------------------------------------ 
 * MIT License
 * 
-* Copyright (c) 2016-2024 Olivier BARRY
+* Copyright (c) 2016-2025 Olivier BARRY
 * 
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/test/TestView2.java
+++ b/src/com/aventura/test/TestView2.java
@@ -17,7 +17,7 @@ import com.aventura.view.MapView;
 * ------------------------------------------------------------------------------ 
 * MIT License
 * 
-* Copyright (c) 2016-2024 Olivier BARRY
+* Copyright (c) 2016-2025 Olivier BARRY
 * 
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/tools/color/ColorTools.java
+++ b/src/com/aventura/tools/color/ColorTools.java
@@ -8,7 +8,7 @@ import com.aventura.math.vector.Tools;
  * ------------------------------------------------------------------------------ 
  * MIT License
  * 
- * Copyright (c) 2016-2024 Olivier BARRY
+ * Copyright (c) 2016-2025 Olivier BARRY
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/tools/tracing/Tracer.java
+++ b/src/com/aventura/tools/tracing/Tracer.java
@@ -3,13 +3,38 @@ package com.aventura.tools.tracing;
 import java.io.*;
 
 /**
+ * ------------------------------------------------------------------------------ 
+ * MIT License
+ * 
+ * Copyright (c) 2016-2025 Olivier BARRY
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * ------------------------------------------------------------------------------ 
+ * 
  * New Tracer implementation.
  * Static methods
  * Allow to test activation at tracing stage
  * Less heavy (no additional methods in each class)
  * 
  * @author Olivier BARRY
- * @version 1.0
+ * @since November 2016
+ * 
  */
 
 public class Tracer {

--- a/src/com/aventura/view/GUIView.java
+++ b/src/com/aventura/view/GUIView.java
@@ -8,7 +8,7 @@ import com.aventura.context.PerspectiveContext;
 * ------------------------------------------------------------------------------ 
 * MIT License
 * 
-* Copyright (c) 2016-2024 Olivier BARRY
+* Copyright (c) 2016-2025 Olivier BARRY
 * 
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/view/MapView.java
+++ b/src/com/aventura/view/MapView.java
@@ -4,7 +4,7 @@ package com.aventura.view;
 * ------------------------------------------------------------------------------ 
 * MIT License
 * 
-* Copyright (c) 2016-2024 Olivier BARRY
+* Copyright (c) 2016-2025 Olivier BARRY
 * 
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/view/SwingView.java
+++ b/src/com/aventura/view/SwingView.java
@@ -12,7 +12,7 @@ import com.aventura.tools.tracing.Tracer;
 * ------------------------------------------------------------------------------ 
 * MIT License
 * 
-* Copyright (c) 2016-2024 Olivier BARRY
+* Copyright (c) 2016-2025 Olivier BARRY
 * 
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/src/com/aventura/view/View.java
+++ b/src/com/aventura/view/View.java
@@ -4,7 +4,7 @@ package com.aventura.view;
 * ------------------------------------------------------------------------------ 
 * MIT License
 * 
-* Copyright (c) 2016-2024 Olivier BARRY
+* Copyright (c) 2016-2025 Olivier BARRY
 * 
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
RasterizeScanLine method was not calculating Colors for each light in case of normal at triangle level. This is now fixed.