### PR TITLE
PerspectiveContext improvements + FPS counter (Stats traces)

### DIFF
--- a/src/com/aventura/context/PerspectiveContext.java
+++ b/src/com/aventura/context/PerspectiveContext.java
@@ -160,7 +160,43 @@ public class PerspectiveContext {
 	}
 	
 	/**
-	 * @param width
+	 * @param pixel_width number of pixel for the width of this perspective
+	 * @param pixel_height number of pixel for the height of this perspective
+	 * @param dist
+	 * @param depth
+	 * @param perspective type of perspective (Orthographic or Frustum)
+	 * @param ppu point per unit
+	 */
+	public PerspectiveContext(int pixel_width, int pixel_height, float dist, float depth, int perspective, int ppu) {
+		if (Tracer.function) Tracer.traceFunction(this.getClass(), "New perspectiveContext: pixel width: " + pixel_width + " pixel height:" + pixel_height + " dist: " + dist + " depth: " + depth +" ppu: " + ppu + " type: "+getTypeString(perspective));
+
+		this.p_type = perspective;
+		this.ppu = ppu;
+
+		this.pixelWidth = pixel_width;
+		this.pixelHeight = pixel_height;
+		this.pixelHalfWidth = pixelWidth/2;
+		this.pixelHalfHeight = pixelHeight/2;
+		
+		createPerspective(perspective, pixel_width/ppu , pixel_height/ppu, dist, depth);
+	}
+	
+	public PerspectiveContext(int pixel_width, float width, float height, float dist, float depth, int perspective) {
+		if (Tracer.function) Tracer.traceFunction(this.getClass(), "New perspectiveContext: pixel width: "+pixel_width+" width: "+width+" height:"+height+" dist: "+dist+" depth: "+depth+" type: "+getTypeString(perspective));
+
+		this.p_type = perspective;
+		this.ppu = (int)(pixel_width/width);
+
+		this.pixelWidth = pixel_width;
+		this.pixelHeight = (int)(height*ppu);
+		this.pixelHalfWidth = pixelWidth/2;
+		this.pixelHalfHeight = pixelHeight/2;
+		
+		createPerspective(perspective, width , height, dist, depth);
+	}
+
+	/**
+	 * @param width 
 	 * @param height
 	 * @param dist
 	 * @param depth
@@ -180,7 +216,17 @@ public class PerspectiveContext {
 		
 		createPerspective(perspective, width , height, dist, depth);
 	}
-	
+
+	/**
+	 * @param top
+	 * @param bottom
+	 * @param right
+	 * @param left
+	 * @param far
+	 * @param near
+	 * @param perspective
+	 * @param ppu
+	 */
 	public PerspectiveContext(float top, float bottom, float right, float left, float far, float near, int perspective, int ppu) {
 		if (Tracer.function) Tracer.traceFunction(this.getClass(), "New perspectiveContext: top: "+top+" bottom: "+bottom+" right: "+right+" left: "+left+" far: "+far+" near: "+near+" ppu: "+ppu+" type: "+getTypeString(perspective));
 		
@@ -206,6 +252,14 @@ public class PerspectiveContext {
 		}
 	}
 	
+	/**
+	 * Create a Perspective with width, height, dist and depth
+	 * @param p_type type of perspective (Orthographic or Frustum)
+	 * @param width
+	 * @param height
+	 * @param dist
+	 * @param depth
+	 */
 	protected void createPerspective(int p_type, float width, float height, float dist, float depth) {
 		if (Tracer.function) Tracer.traceFunction(this.getClass(), "Creating perspective: width: "+width+" height: "+height+" dist: "+dist+" depth: "+depth);
 		
@@ -223,6 +277,16 @@ public class PerspectiveContext {
 		if (Tracer.info) Tracer.traceInfo(this.getClass(), "Created perspective : \n" + this.perspective);	
 	}
 	
+	/**
+	 * Create a Perspective with left, right bottom, top, near far
+	 * @param p_type type of perspective (Orthographic or Frustum)
+	 * @param left
+	 * @param right
+	 * @param bottom
+	 * @param top
+	 * @param near
+	 * @param far
+	 */
 	protected void createPerspective(int p_type, float left, float right, float bottom, float top, float near, float far) {
 		if (Tracer.function) Tracer.traceFunction(this.getClass(), "Creating perspective: top: "+top+" bottom: "+bottom+" right: "+right+" left: "+left+" far: "+far+" near: "+near);
 		

--- a/src/com/aventura/engine/RenderEngine.java
+++ b/src/com/aventura/engine/RenderEngine.java
@@ -184,6 +184,7 @@ public class RenderEngine {
 	public MapView render() {
 		
 		if (Tracer.function) Tracer.traceFunction(this.getClass(), "Start rendering...");
+		long start_millisec = System.currentTimeMillis();
 		nbt = 0;
 		nbt_in = 0;
 		nbt_out = 0;
@@ -270,6 +271,11 @@ public class RenderEngine {
 
 		// Switch back and front buffers and request GUI repaint
 		gUIView.renderView();
+		
+		long end_millisec = System.currentTimeMillis();
+		
+		long duration_millisec = end_millisec - start_millisec;
+		if (Tracer.stats) Tracer.traceStats(this.getClass(), "Rendering duration : " + duration_millisec + " millisec, FPS : " + (float)1000/duration_millisec);			
 		
 		return zBuffer;
 	}

--- a/src/com/aventura/math/tools/BoundingBox4.java
+++ b/src/com/aventura/math/tools/BoundingBox4.java
@@ -65,7 +65,7 @@ public class BoundingBox4 {
 		minY = maxY = arrayOfPoints[0].getY();
 		minZ = maxZ = arrayOfPoints[0].getZ();
 		
-		// Itearate on the rest of the list and keep the min and max of each coordinate
+		// Iterate on the rest of the list and keep the min and max of each coordinate
 		for (int i=1; i<arrayOfPoints.length; i++) {
 			float x = arrayOfPoints[i].getX();
 			float y = arrayOfPoints[i].getY();
@@ -90,24 +90,36 @@ public class BoundingBox4 {
 		boxPoints[1][3] = new Vector4(maxX, maxY, minZ, 1);
 	}
 	
-	public float getMaxX() {
+	protected float getMaxX() {
 		return maxX;
 	}
-	public float getMaxY() {
+	protected float getMaxY() {
 		return maxY;
 	}
-	public float getMaxZ() {
+	protected float getMaxZ() {
 		return maxZ;
 	}
 	
-	public float getMinX() {
+	protected float getMinX() {
 		return minX;
 	}
-	public float getMinY() {
+	protected float getMinY() {
 		return minY;
 	}
-	public float getMinZ() {
+	protected float getMinZ() {
 		return minZ;
+	}
+	
+	public float getWidth() {
+		return maxX - minX;
+	}
+	
+	public float getHeight() {
+		return maxY - minY;
+	}
+	
+	public float getDepth() {
+		return maxZ - minZ;	
 	}
 	
 	public Vector4 getP11() {

--- a/src/com/aventura/model/light/DirectionalLight.java
+++ b/src/com/aventura/model/light/DirectionalLight.java
@@ -278,7 +278,11 @@ public class DirectionalLight extends ShadowingLight {
 		
 		// TODO PPU calculation is NOT DEFAULT_SHADOW_MAP_DIMENSION
 		//perspectiveCtx_light = new PerspectiveContext(box.getMaxY(), box.getMinY(), box.getMaxX(), box.getMinX(), box.getMaxZ()-box.getMinZ(), light_eye.length(), PerspectiveContext.PERSPECTIVE_TYPE_ORTHOGRAPHIC, DEFAULT_SHADOW_MAP_DIMENSION);
-		perspectiveCtx_light = new PerspectiveContext(12.8f, 12.8f, 0.1f, 10, PerspectiveContext.PERSPECTIVE_TYPE_ORTHOGRAPHIC, 78);
+		//perspectiveCtx_light = new PerspectiveContext(12.8f, 12.8f, 0.1f, 10, PerspectiveContext.PERSPECTIVE_TYPE_ORTHOGRAPHIC, 78);
+		//perspectiveCtx_light = new PerspectiveContext(1000, 1000, 0.1f, 10, PerspectiveContext.PERSPECTIVE_TYPE_ORTHOGRAPHIC,80);
+		//perspectiveCtx_light = new PerspectiveContext(1000, 15.0f, 15.0f, 0.1f, 10.0f, PerspectiveContext.PERSPECTIVE_TYPE_ORTHOGRAPHIC);
+		perspectiveCtx_light = new PerspectiveContext(1000, box.getWidth(), box.getHeight(), 0.1f, box.getDepth(), PerspectiveContext.PERSPECTIVE_TYPE_ORTHOGRAPHIC);
+		
 		map_size = perspectiveCtx_light.getPixelWidth();
 		if (perspectiveCtx_light.getPixelWidth() != perspectiveCtx_light.getPixelHeight()) {
 			// Should never happen

--- a/src/com/aventura/model/world/World.java
+++ b/src/com/aventura/model/world/World.java
@@ -228,6 +228,9 @@ public class World {
 		float dist = 0;
 		for (int i=0; i<elements.size(); i++) {
 			for (int j=0; j<elements.get(i).vertices.size(); j++) {
+				// BUG : this does not calculate the position of the vertices using the Element's transformation hence not the Max Distance in World coordinates
+				//TODO calculate using wld_position instead of postion
+				//TODO need to calculate wld_position before rendering (as this is geometry calculation, not projection)
 				dist = elements.get(i).vertices.get(j).position.length();
 				max = dist > max ? dist : max;
 			}
@@ -244,6 +247,9 @@ public class World {
 		if (p.isVector()) p.point();
 		for (int i=0; i<elements.size(); i++) {
 			for (int j=0; j<elements.get(i).vertices.size(); j++) {
+				// BUG : this does not calculate the position of the vertices using the Element's transformation hence not the Max Distance in World coordinates
+				//TODO calculate using wld_position instead of postion
+				//TODO need to calculate wld_position before rendering (as this is geometry calculation, not projection)
 				dist = elements.get(i).vertices.get(j).position.minus(p).length();
 				max = dist > max ? dist : max;
 			}

--- a/src/com/aventura/test/TestShadowMapRasterization.java
+++ b/src/com/aventura/test/TestShadowMapRasterization.java
@@ -102,7 +102,8 @@ public class TestShadowMapRasterization {
 		System.out.println("********* STARTING APPLICATION *********");
 		Tracer.info = true;
 		Tracer.function = true;
-		Tracer.debug = true;
+		//Tracer.debug = true;
+		Tracer.stats = true;
 		
 		// Camera
 		//Vector4 eye = new Vector4(-8,-2,12,1);
@@ -201,7 +202,6 @@ public class TestShadowMapRasterization {
 		if (mapView != null) {
 			System.out.println("Now rendering shadow map...");
 			System.out.println("ShadowMap min: "+mapView.getMin() + ", ShadowMap max: "+mapView.getMax() + ", ShadowMap avg: " + mapView.getAverage() + ". Nb of Pixels around min: " + mapView.getNbOfPixelsInRange(mapView.getMin(), mapView.getMin()+0.01f*(mapView.getMax()-mapView.getMin())) + ". Nb of Pixels around max: " + mapView.getNbOfPixelsInRange(mapView.getMax()-0.01f*(mapView.getMax()-mapView.getMin()), mapView.getMax())+ ". Nb of Pixels in map: " + mapView.getNbOfPixels());
-			//mapView.removeFar(pContext.getPerspective().getFar(), 0);
 			mapView.normalizeMap();
 			gUIView.setDimensions(mapView.getViewWidth(), mapView.getViewHeight());
 			gUIView.initView(mapView);


### PR DESCRIPTION
Improve Perspective context to calculate a perspective and defining a pixel width for the map. This is useful for the ShadowMap calculation to keep a constant pixel size while having a variable width. Use Bounding Box dimension to calculate the PerspectiveContext. Identify BUG : World Bounding Box does not take account of Element's transformations (translations etc.).

Implement FPS counter in RenderEngine. For the moment it is dieplayed as Stats traces (need enablement of this level).