### PR TITLE
Shadows are stablized now and Tests implemented

### DIFF
--- a/src/com/aventura/context/PerspectiveContext.java
+++ b/src/com/aventura/context/PerspectiveContext.java
@@ -188,7 +188,21 @@ public class PerspectiveContext {
 		this.ppu = (int)(pixel_width/width);
 
 		this.pixelWidth = pixel_width;
-		this.pixelHeight = (int)(height*ppu);
+		// BUGFIX: this used to be (int)(height*ppu) -- going through ppu (an int, already
+		// truncated from pixel_width/width) compounds a second truncation on top of the first.
+		// Even when height == width EXACTLY (as DirectionalLight.initShadowing() guarantees for
+		// its square-footprint shadow box), the two independent truncations could disagree --
+		// e.g. width=10.733126, pixel_width=500 gave ppu=(int)46.58=46, then
+		// pixelHeight=(int)(10.733126*46)=493, while pixelWidth stayed the exact requested 500.
+		// That single-pixel-class mismatch was enough to desynchronize ShadowingLight's ZBuffer
+		// half-height (derived from pixelWidth alone) from TriangleRasterizer's actual
+		// getPixelHalfHeight() (derived from this pixelHeight), producing a small constant
+		// vertical write/read offset in shadow map sampling -- see the accompanying message for
+		// the full trace that led here.
+		// Fix: derive pixelHeight from pixelWidth and the exact (float) height/width ratio in a
+		// single rounding step, instead of round-tripping through the separately-truncated ppu.
+		// When height == width bit-for-bit, this reduces to exactly pixel_width, no exceptions.
+		this.pixelHeight = Math.round(pixel_width * (height / width));
 		this.pixelHalfWidth = pixelWidth/2;
 		this.pixelHalfHeight = pixelHeight/2;
 		

--- a/src/com/aventura/engine/ShadingConsumer.java
+++ b/src/com/aventura/engine/ShadingConsumer.java
@@ -44,11 +44,6 @@ import com.aventura.view.GUIView;
  * to Lighting.ambientContributionAt()/contributionOf(), with this class only
  * orchestrating the loop over lights and the shadow weighting.
  *
- * DEPENDENCY NOTE: this class calls ShadowingLight.shadowFactorAt(Vector4),
- * which doesn't exist yet on ShadowingLight — it's part of the next step
- * (the Lighting/Light fixes + shadow factor addition). This class is
- * otherwise complete and won't need further changes once that method lands.
- *
  * @author Olivier BARRY
  * @since 2026
  *
@@ -90,7 +85,7 @@ public class ShadingConsumer implements FragmentConsumer {
 		if (lighting.getShadowingLights() != null) {
 			for (ShadowingLight light : lighting.getShadowingLights()) {
 
-				if (shadowsEnabled && light.shadowFactorAt(fragment.getWorldPosition()) <= 0) {
+				if (shadowsEnabled && light.shadowFactorAt(fragment.getWorldPosition(), fragment.getNormal()) <= 0) {
 					// Fully in shadow for this light -- nothing to add. NOTE: shadowFactorAt()
 					// today only ever returns 0 or 1 (hard shadows, no PCF/soft shadows yet -- see
 					// its Javadoc), so a binary skip-or-include here is sufficient; if soft shadows

--- a/src/com/aventura/model/light/ShadowingLight.java
+++ b/src/com/aventura/model/light/ShadowingLight.java
@@ -7,6 +7,7 @@ import com.aventura.engine.RasterizerStats;
 import com.aventura.engine.TriangleRasterizer;
 import com.aventura.engine.ViewProjection;
 import com.aventura.engine.ZBuffer;
+import com.aventura.math.vector.Vector3;
 import com.aventura.math.vector.Vector4;
 import com.aventura.model.camera.Camera;
 import com.aventura.model.perspective.Perspective;
@@ -63,7 +64,7 @@ public abstract class ShadowingLight extends Light {
 	// independent of the light box's world-space extent (see the "TODO PPU calculation" removed
 	// from there -- this constant is that fix). Not yet exposed through PerspectiveContext /
 	// RenderContext's configuration surface -- see the backlog note on that method.
-	public static final int DEFAULT_SHADOW_MAP_DIMENSION = 500;
+	public static final int DEFAULT_SHADOW_MAP_DIMENSION = 1000;
 	
 	// Parameter for Shadow Mapping "box" definition (used for Light's camera and perspective calculation)
 	public static final int SHADOWING_BOX_WORLD = 1; // Use the World's max dimensions to calculate the Light's view box
@@ -118,15 +119,26 @@ public abstract class ShadowingLight extends Light {
 	// range instead of the old, much deeper, arbitrary one: the same "10*EPSILON" that used to be
 	// enough stopped being enough, producing self-shadowing acne on grazing-angle surfaces (e.g.
 	// this class's flat Trellis floor under a near-horizontal DirectionalLight).
-	// TODO (backlog): this is still a single fixed value, not slope-scaled by the angle between
-	// the surface and the light (dotNL) -- a very grazing angle can still need more bias than a
-	// perpendicular one. Left as a further refinement; requires threading the fragment's normal
-	// (or dotNL) into shadowFactorAt(), a signature change not made in this pass.
 	protected static final float SHADOW_BIAS_WORLD = 0.02f;
-	// Derived from SHADOW_BIAS_WORLD and this light's current depth range -- (re)computed once per
-	// generateShadowMap(World) call (perspectiveCtx_light is only valid after initShadowing() has
-	// run), then reused by every shadowFactorAt() call for that frame.
-	protected float ndcShadowBias = 0f;
+
+	// Slope scaling: the depth-quantization error a fixed world bias needs to absorb grows
+	// roughly as 1/dotNL as the surface tilts away from facing the light (dotNL -> 0 at a
+	// grazing angle) -- a bias tuned for a well-lit surface (dotNL close to 1) can still be too
+	// small for a much more grazing one, even one that doesn't look extreme (e.g. dotNL ~ 0.4,
+	// ~66 degrees off the normal, already needed noticeably more bias than dotNL ~ 0.67 in
+	// testing). shadowFactorAt() now divides the base bias by max(dotNL, DOT_NL_FLOOR) instead of
+	// using one fixed value for every angle. DOT_NL_FLOOR caps this scaling at near-grazing
+	// incidence (dotNL -> 0 would otherwise blow the bias up to infinity); hardcoded for now, see
+	// backlog note about grouping this with SHADOW_BIAS_WORLD and other hardcoded tuning
+	// constants once we revisit making them configurable.
+	protected static final float DOT_NL_FLOOR = 0.1f;
+
+	// Base bias in NDC depth units (SHADOW_BIAS_WORLD converted using this light's CURRENT
+	// (far-near) depth range), BEFORE the per-fragment slope scaling above is applied.
+	// (Re)computed once per generateShadowMap(World) call (perspectiveCtx_light is only valid
+	// after initShadowing() has run), then reused -- with a different slope factor each time --
+	// by every shadowFactorAt() call for that frame.
+	protected float ndcShadowBiasBase = 0f;
 	
 	// Default constructor
 	public ShadowingLight() {
@@ -248,8 +260,10 @@ public abstract class ShadowingLight extends Light {
 		// See SHADOW_BIAS_WORLD's Javadoc: converts the fixed world-space bias into this frame's
 		// NDC depth units, using this light's CURRENT (far-near) depth range -- so the physical
 		// tolerance stays constant even as initShadowing() recomputes a tighter or looser box.
+		// This is the BASE bias only -- shadowFactorAt() further scales it per-fragment by the
+		// surface's slope relative to this light (see DOT_NL_FLOOR's Javadoc).
 		float depthRange = perspectiveCtx_light.getPerspective().getDepth();
-		ndcShadowBias = depthRange > 0 ? SHADOW_BIAS_WORLD / depthRange : SHADOW_BIAS_WORLD;
+		ndcShadowBiasBase = depthRange > 0 ? SHADOW_BIAS_WORLD / depthRange : SHADOW_BIAS_WORLD;
 
 		// Recompute this light's View*Projection from its camera's CURRENT state, in case the
 		// light itself moved since the last generation (same reasoning as
@@ -318,9 +332,11 @@ public abstract class ShadowingLight extends Light {
 	 * matrix handling is needed here, which is what the legacy code was missing.
 	 *
 	 * @param worldPosition world-space position to test (e.g. Fragment.getWorldPosition())
+	 * @param normal        world-space surface normal at worldPosition (e.g. Fragment.getNormal()),
+	 *                      used to slope-scale the anti-acne bias -- see DOT_NL_FLOOR's Javadoc.
 	 * @return 1.0 if fully lit, 0.0 if in shadow
 	 */
-	public float shadowFactorAt(Vector4 worldPosition) {
+	public float shadowFactorAt(Vector4 worldPosition, Vector3 normal) {
 
 		if (map == null) {
 			// No shadow map generated (yet) for this light -- treat as fully lit rather than
@@ -333,8 +349,12 @@ public abstract class ShadowingLight extends Light {
 		// Map is stored in [0, 1] while clip-space coordinates are in [-1, 1].
 		float depth = map.getInterpolation((posInLightSpace.getX() + 1) / 2, (posInLightSpace.getY() + 1) / 2);
 
-		// Epsilon bias to avoid "shadow acne" (self-shadowing) -- see ndcShadowBias's Javadoc for
-		// why this is now derived per-light-per-frame instead of a fixed constant.
+		// Slope-scaled epsilon bias to avoid "shadow acne" (self-shadowing) -- see
+		// DOT_NL_FLOOR's Javadoc for why a single fixed bias (ndcShadowBiasBase alone) isn't
+		// enough across every incidence angle.
+		float dotNL = getLightVectorAtPoint(worldPosition).dot(normal.normalize());
+		float ndcShadowBias = ndcShadowBiasBase / Math.max(dotNL, DOT_NL_FLOOR);
+
 		if (posInLightSpace.getZ() > depth + ndcShadowBias) {
 			return 0f;
 		}

--- a/src/com/aventura/model/light/ShadowingLight.java
+++ b/src/com/aventura/model/light/ShadowingLight.java
@@ -7,7 +7,6 @@ import com.aventura.engine.RasterizerStats;
 import com.aventura.engine.TriangleRasterizer;
 import com.aventura.engine.ViewProjection;
 import com.aventura.engine.ZBuffer;
-import com.aventura.math.Constants;
 import com.aventura.math.vector.Vector4;
 import com.aventura.model.camera.Camera;
 import com.aventura.model.perspective.Perspective;
@@ -109,6 +108,25 @@ public abstract class ShadowingLight extends Light {
 	// shadow-calculation rework mentioned in the backlog is still pending.
 	protected RasterizerStats shadowMapStats = new RasterizerStats();
 	private int trianglesThisGeneration = 0; // reset at the start of each generateShadowMap(World) call
+
+	// Anti-acne depth bias, expressed as a WORLD-space distance (a physically meaningful depth
+	// tolerance, independent of how tight or loose this light's box happens to be) rather than a
+	// fixed slice of the [0,1] NDC depth range. A fixed NDC epsilon (the legacy "10*EPSILON")
+	// implicitly means a much SMALLER world-space bias for a tight-fit box than for a loose one
+	// (world bias = ndcEpsilon * (far-near)) -- which is exactly what turned invisible once the
+	// box calculation in DirectionalLight.initShadowing() started producing a tight-fit depth
+	// range instead of the old, much deeper, arbitrary one: the same "10*EPSILON" that used to be
+	// enough stopped being enough, producing self-shadowing acne on grazing-angle surfaces (e.g.
+	// this class's flat Trellis floor under a near-horizontal DirectionalLight).
+	// TODO (backlog): this is still a single fixed value, not slope-scaled by the angle between
+	// the surface and the light (dotNL) -- a very grazing angle can still need more bias than a
+	// perpendicular one. Left as a further refinement; requires threading the fragment's normal
+	// (or dotNL) into shadowFactorAt(), a signature change not made in this pass.
+	protected static final float SHADOW_BIAS_WORLD = 0.02f;
+	// Derived from SHADOW_BIAS_WORLD and this light's current depth range -- (re)computed once per
+	// generateShadowMap(World) call (perspectiveCtx_light is only valid after initShadowing() has
+	// run), then reused by every shadowFactorAt() call for that frame.
+	protected float ndcShadowBias = 0f;
 	
 	// Default constructor
 	public ShadowingLight() {
@@ -205,10 +223,33 @@ public abstract class ShadowingLight extends Light {
 		// previous frame in a scene with moving lights/geometry. This replaces the old
 		// rasterizer_light.initZBuffer(...) call (which mutated a persistent Rasterizer instance).
 		int half = map_size / 2;
-		ZBuffer shadowZBuffer = new ZBuffer(map_size, map_size, half, half, Float.MAX_VALUE);
+		// Orthographic projections in this engine always normalize NDC depth to [0, 1] (see
+		// OrthographicProjection's matrix -- z_ndc = 0 at near, 1 at far, regardless of the actual
+		// near/far world-space values chosen). Float.MAX_VALUE used to be used here as a generic
+		// "further than anything real" sentinel, but it is NOT close to 1 -- so any part of the
+		// map never touched by a triangle (e.g. the square map's corners outside a diamond-shaped
+		// Trellis footprint) stayed at Float.MAX_VALUE, which then dominated
+		// MapView.normalizeMap()'s min/max range so completely that every REAL depth value (0..1)
+		// collapsed to ~0 (solid black, no visible gradient) when displayed -- purely a display
+		// artifact of the debug shadow map view, NOT a bug in shadowFactorAt() itself (which reads
+		// raw depth values directly, not normalized ones, so it was never affected).
+		// A small margin above 1.0 guards against a fragment exactly at the box's far corner
+		// (z_ndc mathematically == 1.0, see DirectionalLight.initShadowing()'s far/near derivation)
+		// failing the depth test (z <= stored) purely from floating-point rounding.
+		// TODO: if/when PointLight/SpotLight shadow maps are implemented with a Frustum (not
+		// Orthographic) projection, re-check whether their NDC depth convention is also [0,1] --
+		// this constant assumes it is.
+		final float SHADOW_MAP_FAR_NDC = 1.0f + 1e-4f;
+		ZBuffer shadowZBuffer = new ZBuffer(map_size, map_size, half, half, SHADOW_MAP_FAR_NDC);
 		this.map = shadowZBuffer.getMapView(); // getMap()/getMap(x,y) keep working exactly as before
 		TriangleRasterizer rasterizer = new TriangleRasterizer(perspectiveCtx_light, shadowZBuffer);
 		DepthOnlyConsumer consumer = new DepthOnlyConsumer(shadowZBuffer);
+
+		// See SHADOW_BIAS_WORLD's Javadoc: converts the fixed world-space bias into this frame's
+		// NDC depth units, using this light's CURRENT (far-near) depth range -- so the physical
+		// tolerance stays constant even as initShadowing() recomputes a tighter or looser box.
+		float depthRange = perspectiveCtx_light.getPerspective().getDepth();
+		ndcShadowBias = depthRange > 0 ? SHADOW_BIAS_WORLD / depthRange : SHADOW_BIAS_WORLD;
 
 		// Recompute this light's View*Projection from its camera's CURRENT state, in case the
 		// light itself moved since the last generation (same reasoning as
@@ -292,9 +333,9 @@ public abstract class ShadowingLight extends Light {
 		// Map is stored in [0, 1] while clip-space coordinates are in [-1, 1].
 		float depth = map.getInterpolation((posInLightSpace.getX() + 1) / 2, (posInLightSpace.getY() + 1) / 2);
 
-		// Epsilon bias to avoid "shadow acne" (self-shadowing) -- same value and reasoning as the
-		// legacy code.
-		if (posInLightSpace.getZ() > depth + 10 * Constants.EPSILON) {
+		// Epsilon bias to avoid "shadow acne" (self-shadowing) -- see ndcShadowBias's Javadoc for
+		// why this is now derived per-light-per-frame instead of a fixed constant.
+		if (posInLightSpace.getZ() > depth + ndcShadowBias) {
 			return 0f;
 		}
 		return 1f;

--- a/src/com/aventura/test/TestMultiElementsInterpolateShadows.java
+++ b/src/com/aventura/test/TestMultiElementsInterpolateShadows.java
@@ -1,0 +1,202 @@
+package com.aventura.test;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Toolkit;
+
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.WindowConstants;
+
+import com.aventura.context.PerspectiveContext;
+import com.aventura.context.RenderContext;
+import com.aventura.engine.RenderEngine;
+import com.aventura.math.transform.Rotation;
+import com.aventura.math.transform.Transformation;
+import com.aventura.math.transform.Translation;
+import com.aventura.math.vector.Vector3;
+import com.aventura.math.vector.Vector4;
+import com.aventura.model.camera.Camera;
+import com.aventura.model.light.AmbientLight;
+import com.aventura.model.light.DirectionalLight;
+import com.aventura.model.light.Lighting;
+import com.aventura.model.world.Element;
+import com.aventura.model.world.World;
+import com.aventura.model.world.shape.Box;
+import com.aventura.model.world.shape.Cone;
+import com.aventura.model.world.shape.Cube;
+import com.aventura.model.world.shape.Cylinder;
+import com.aventura.model.world.shape.Sphere;
+import com.aventura.model.world.shape.Trellis;
+import com.aventura.view.SwingView;
+import com.aventura.view.GUIView;
+
+/**
+ * ------------------------------------------------------------------------------ 
+ * MIT License
+ * 
+ * Copyright (c) 2016-2026 Olivier BARRY
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * ------------------------------------------------------------------------------
+ * 
+ * This class is a Test class demonstrating usage of the API of the Aventura rendering engine 
+ */
+
+public class TestMultiElementsInterpolateShadows {
+	
+	// GUIView to be displayed
+	private SwingView view;
+	
+	public GUIView createView(PerspectiveContext context) {
+
+		// Create the frame of the application 
+		JFrame frame = new JFrame("Test Multi Elements Interpolate");
+		// Set the size of the frame
+		frame.setSize(context.getPixelWidth(), context.getPixelHeight());
+		
+		// Create the gUIView to be displayed
+		view = new SwingView(context, frame);
+		
+		// Create a panel and add it to the frame
+		JPanel panel = new JPanel() {
+			
+		    public void paintComponent(Graphics graph) {
+		    	graph.drawImage(view.getImageView(), 0, 0, null);
+		    }
+		};
+		frame.getContentPane().add(panel);
+		frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+ 
+		// Locate application frame in the center of the screen
+		Dimension dim = Toolkit.getDefaultToolkit().getScreenSize();
+		frame.setLocation(dim.width/2 - frame.getWidth()/2, dim.height/2 - frame.getHeight()/2);
+		
+		// Render the frame on the display
+		frame.setVisible(true);
+		
+		return view;
+	}
+	
+
+	/**
+	 * @param args
+	 */
+	public static void main(String[] args) {
+
+		System.out.println("********* STARTING APPLICATION *********");
+		
+		// Camera
+		Vector4 eye = new Vector4(10,6,3,1);
+		Vector4 poi = new Vector4(0,0,0,1);
+		Camera camera = new Camera(eye, poi, Vector4.Z_AXIS);		
+				
+		TestMultiElementsInterpolateShadows test = new TestMultiElementsInterpolateShadows();
+				
+		// Create a new World
+		System.out.println("********* Creating World");
+		World world = new World();
+		world.setBackgroundColor(Color.BLACK);
+		Element e;
+		
+		for (int i=-1; i<=1; i++) {
+			for (int j=-1; j<=1; j++) {
+				for (int k=-1; k<=1; k++) {
+										
+					// Create an Element of a random type
+					switch(Math.round((float)Math.random()*5)) {
+					case 0:
+						e = new Cone(1,0.5f,32);
+						e.setColor(Color.YELLOW);
+						break;
+					case 1:
+						e = new Cylinder(1,0.5f,32);
+						e.setColor(Color.CYAN);
+						break;
+					case 2:
+						e = new Sphere(0.8f,32);
+						e.setColor(Color.MAGENTA);
+						break;
+					case 3:
+						e = new Cube(1);
+						e.setColor(Color.PINK);
+						break;
+					case 4:
+						e = new Box(1,0.5f,0.3f);
+						e.setColor(Color.ORANGE);
+						break;
+					case 5:
+						e = new Trellis(1,1,8,8);
+						e.setColor(Color.GREEN);
+						break;
+					default:
+						e = null;
+					}
+					
+					// Translate this element at some i,j,k indices of a 3D cube:
+					Translation t = new Translation(new Vector3(i*2, j*2, k*2));
+					e.setTransformation(t);
+
+					// Add the element to the world
+					world.addElement(e);
+				}
+			}
+		}
+		
+		// Calculate normals
+		world.build();
+		
+		System.out.println(world);
+		for (int i=0; i<world.getNbElements(); i++)
+			System.out.println(world.getElement(i));
+
+
+		// Create lighting
+		System.out.println("********* Creating Lighting");
+		DirectionalLight dl = new DirectionalLight(new Vector3(-1,0.5f,-0.5f), 0.7f);
+		AmbientLight al = new AmbientLight(0.3f);
+		Lighting lighting = new Lighting(dl, al);
+
+		PerspectiveContext context = new PerspectiveContext(1.5f, 0.9f, 1, 100, PerspectiveContext.PERSPECTIVE_TYPE_FRUSTUM, 1000);
+		GUIView gUIView = test.createView(context);
+
+		RenderContext rContext = new RenderContext(RenderContext.RENDER_STANDARD_INTERPOLATE_WITH_LANDMARKS);
+		rContext.setShadowing(RenderContext.SHADOWING_ENABLED);
+		
+		RenderEngine renderer = new RenderEngine(world, lighting, camera, rContext, context);
+		renderer.setView(gUIView);
+		renderer.render();
+		
+		System.out.println("********* Rendering...");
+		int nb_images = 3600;
+		int speed = 3;
+		Rotation r1 = new Rotation((float)Math.PI*2*speed/(float)nb_images, Vector3.X_AXIS);
+		Rotation r2 = new Rotation((float)Math.PI*2*1.5f*speed/(float)nb_images, Vector3.Y_AXIS);
+		Rotation r3 = new Rotation((float)Math.PI*2*2.5f*speed/(float)nb_images, Vector3.Z_AXIS);
+		Transformation r = new Transformation(r1.times(r2).times(r3));
+		for (int i=0; i<=nb_images; i++) {
+			world.expandTransformation(r);
+			renderer.render();
+		}
+
+		System.out.println("********* ENDING APPLICATION *********");
+
+	}
+}

--- a/src/com/aventura/test/TestMultiElementsShadows.java
+++ b/src/com/aventura/test/TestMultiElementsShadows.java
@@ -1,0 +1,207 @@
+package com.aventura.test;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Toolkit;
+
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.WindowConstants;
+
+import com.aventura.context.PerspectiveContext;
+import com.aventura.context.RenderContext;
+import com.aventura.engine.RenderEngine;
+import com.aventura.math.transform.Translation;
+import com.aventura.math.vector.Tools;
+import com.aventura.math.vector.Vector3;
+import com.aventura.math.vector.Vector4;
+import com.aventura.model.camera.Camera;
+import com.aventura.model.light.AmbientLight;
+import com.aventura.model.light.DirectionalLight;
+import com.aventura.model.light.Lighting;
+import com.aventura.model.world.Element;
+import com.aventura.model.world.World;
+import com.aventura.model.world.shape.Box;
+import com.aventura.model.world.shape.Cone;
+import com.aventura.model.world.shape.Cube;
+import com.aventura.model.world.shape.Cylinder;
+import com.aventura.model.world.shape.Sphere;
+import com.aventura.model.world.shape.Trellis;
+import com.aventura.view.SwingView;
+import com.aventura.view.GUIView;
+
+/**
+ * ------------------------------------------------------------------------------ 
+ * MIT License
+ * 
+ * Copyright (c) 2016-2026 Olivier BARRY
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * ------------------------------------------------------------------------------
+ * 
+ * This class is a Test class demonstrating usage of the API of the Aventura rendering engine 
+ */
+
+public class TestMultiElementsShadows {
+	
+	// GUIView to be displayed
+	private SwingView view;
+	
+	public GUIView createView(PerspectiveContext context) {
+
+		// Create the frame of the application 
+		JFrame frame = new JFrame("Test Multi Elements");
+		// Set the size of the frame
+		frame.setSize(1000,600);
+		
+		// Create the gUIView to be displayed
+		view = new SwingView(context, frame);
+		
+		// Create a panel and add it to the frame
+		JPanel panel = new JPanel() {
+			
+		    public void paintComponent(Graphics graph) {
+		    	graph.drawImage(view.getImageView(), 0, 0, null);
+		    }
+		};
+		frame.getContentPane().add(panel);
+		frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+ 
+		// Locate application frame in the center of the screen
+		Dimension dim = Toolkit.getDefaultToolkit().getScreenSize();
+		frame.setLocation(dim.width/2 - frame.getWidth()/2, dim.height/2 - frame.getHeight()/2);
+		
+		// Render the frame on the display
+		frame.setVisible(true);
+		
+		return view;
+	}
+	
+	public World createWorld() {
+		
+		// Create a new World
+		World world = new World();
+		world.setBackgroundColor(Color.DARK_GRAY);
+		Element e;
+		
+		for (int i=-2; i<=2; i++) {
+			for (int j=-2; j<=2; j++) {
+				for (int k=-2; k<=2; k++) {
+										
+					// Create an Element of a random type
+					switch(Math.round((float)Math.random()*5)) {
+					case 0:
+						e = new Cone(1,0.5f,8);
+						e.setColor(Color.YELLOW);
+						break;
+					case 1:
+						e = new Cylinder(1,0.5f,8);
+						e.setColor(Color.CYAN);
+						break;
+					case 2:
+						e = new Sphere(1,8);
+						e.setColor(Color.MAGENTA);
+						break;
+					case 3:
+						e = new Cube(1);
+						e.setColor(Color.PINK);
+						break;
+					case 4:
+						e = new Box(1,0.5f,0.3f);
+						e.setColor(Color.ORANGE);
+						break;
+					case 5:
+						e = new Trellis(1,1,8,8);
+						e.setColor(Color.LIGHT_GRAY);
+						break;
+					default:
+						e = null;
+					}
+					
+					// Translate this element at some i,j,k indices of a 3D cube:
+					Translation t = new Translation(new Vector3(i*2, j*2, k*2));
+					e.setTransformation(t);
+
+					// Add the element to the world
+					world.addElement(e);
+				}
+			}
+		}
+		// Calculate normals
+		world.build();
+		
+		// World is created
+		return world;
+	}
+
+	public Lighting createLight() {
+		DirectionalLight dl = new DirectionalLight(new Vector3(-1,-0.8f,-0.5f));
+		AmbientLight al = new AmbientLight(0.2f);
+		Lighting lighting = new Lighting(dl, al);
+		return lighting;
+	}
+
+	/**
+	 * @param args
+	 */
+	public static void main(String[] args) {
+
+		System.out.println("********* STARTING APPLICATION *********");
+		
+		// Camera
+		Vector4 eyeA = new Vector4(60,40,20,1);
+		Vector4 eyeB = new Vector4(4,3,2,1);
+		Vector4 poi = new Vector4(0,0,0,1);
+		Camera camera = new Camera(eyeA, poi, Vector4.Z_AXIS);		
+				
+		TestMultiElementsShadows test = new TestMultiElementsShadows();
+				
+		World world = test.createWorld();
+		Lighting light = test.createLight();
+		PerspectiveContext context = new PerspectiveContext(0.8f, 0.45f, 1, 100, PerspectiveContext.PERSPECTIVE_TYPE_FRUSTUM, 1250);
+		GUIView gUIView = test.createView(context);
+
+		RenderContext rContext = new RenderContext(RenderContext.RENDER_DEFAULT);
+		//rContext.setRendering(RenderContext.RENDERING_TYPE_PLAIN);
+		rContext.setRenderingType(RenderContext.RENDERING_TYPE_INTERPOLATE);
+		rContext.setShadowing(RenderContext.SHADOWING_ENABLED);
+		RenderEngine renderer = new RenderEngine(world, light, camera, rContext, context);
+		renderer.setView(gUIView);
+		int nb_images = 180;
+		for (int i=0; i<=nb_images; i++) {
+			Vector4 eye = Tools.interpolate(eyeA, eyeB, (float)i/nb_images);
+			System.out.println("Interpolation "+i+"  - Eye: "+eye);
+			camera.updateCamera(eye, poi, Vector4.Z_AXIS);
+			renderer.render();
+		}
+		
+		for (int i=0; i<=5*nb_images; i++) {
+			float a = (float)Math.PI*2*(float)i/(float)nb_images;
+			Vector4 eye = new Vector4(30*(float)Math.cos(a),15*(float)Math.sin(a),5,1);
+			System.out.println("Rotation "+i+"  - Eye: "+eye);
+			camera.updateCamera(eye, poi, Vector4.Z_AXIS);
+			renderer.render();
+		}
+		
+		System.out.println("********* ENDING APPLICATION *********");
+
+	}
+
+}

--- a/src/com/aventura/test/TestMultiElementsTextureShadows.java
+++ b/src/com/aventura/test/TestMultiElementsTextureShadows.java
@@ -1,0 +1,250 @@
+package com.aventura.test;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Toolkit;
+
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.WindowConstants;
+
+import com.aventura.context.PerspectiveContext;
+import com.aventura.context.RenderContext;
+import com.aventura.engine.RenderEngine;
+import com.aventura.math.transform.Rotation;
+import com.aventura.math.transform.Transformation;
+import com.aventura.math.transform.Translation;
+import com.aventura.math.vector.Vector3;
+import com.aventura.math.vector.Vector4;
+import com.aventura.model.camera.Camera;
+import com.aventura.model.light.AmbientLight;
+import com.aventura.model.light.DirectionalLight;
+import com.aventura.model.light.Lighting;
+import com.aventura.model.texture.Texture;
+import com.aventura.model.world.Element;
+import com.aventura.model.world.World;
+import com.aventura.model.world.WrongArraySizeException;
+import com.aventura.model.world.shape.Box;
+import com.aventura.model.world.shape.Cone;
+import com.aventura.model.world.shape.Cube;
+import com.aventura.model.world.shape.Cylinder;
+import com.aventura.model.world.shape.Pyramid;
+import com.aventura.model.world.shape.Sphere;
+import com.aventura.model.world.shape.Trellis;
+import com.aventura.view.SwingView;
+import com.aventura.view.GUIView;
+
+/**
+ * ------------------------------------------------------------------------------ 
+ * MIT License
+ * 
+ * Copyright (c) 2016-2026 Olivier BARRY
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * ------------------------------------------------------------------------------
+ * 
+ * This class is a Test class demonstrating usage of the API of the Aventura rendering engine 
+ */
+
+public class TestMultiElementsTextureShadows {
+	
+	// GUIView to be displayed
+	private SwingView view;
+	
+	public GUIView createView(PerspectiveContext context) {
+
+		// Create the frame of the application 
+		JFrame frame = new JFrame("Test Multi Elements with Texture");
+		// Set the size of the frame
+		frame.setSize(context.getPixelWidth(), context.getPixelHeight());
+		
+		// Create the gUIView to be displayed
+		view = new SwingView(context, frame);
+		
+		// Create a panel and add it to the frame
+		JPanel panel = new JPanel() {
+			
+		    public void paintComponent(Graphics graph) {
+		    	graph.drawImage(view.getImageView(), 0, 0, null);
+		    }
+		};
+		frame.getContentPane().add(panel);
+		frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+ 
+		// Locate application frame in the center of the screen
+		Dimension dim = Toolkit.getDefaultToolkit().getScreenSize();
+		frame.setLocation(dim.width/2 - frame.getWidth()/2, dim.height/2 - frame.getHeight()/2);
+		
+		// Render the frame on the display
+		frame.setVisible(true);
+		
+		return view;
+	}
+	
+
+	/**
+	 * @param args
+	 */
+	public static void main(String[] args) {
+
+		System.out.println("********* STARTING APPLICATION *********");
+
+		Texture texbricks = new Texture("resources/texture/texture_bricks_204x204.jpg");
+		//Texture texblue = new Texture("resources/texture/texture_blueground_204x204.jpg");
+		//Texture texwood = new Texture("resources/texture/texture_woodfloor_160x160.jpg");
+		Texture texdamier = new Texture("resources/texture/texture_damier_600x591.gif");
+		Texture texgrass = new Texture("resources/texture/texture_grass_900x600.jpg");
+		//Texture texstone = new Texture("resources/texture/texture_ground_stone_600x600.jpg");
+		//Texture texsnow = new Texture("resources/texture/texture_snow_590x590.jpg");
+		//Texture texmetal = new Texture("resources/texture/texture_metal_mesh_463x463.jpg");
+		//Texture texleather = new Texture("resources/texture/texture_old_leather_box_800x610.jpg");
+		Texture texmetalplate = new Texture("resources/texture/texture_metal_plate_626x626.jpg");
+		//Texture texstone1 = new Texture("resources/texture/texture_stone1_1700x1133.jpg");
+		//Texture texrock = new Texture("resources/texture/texture_rock_stone_400x450.jpg");
+		Texture texcremedemarron = new Texture("resources/texture/texture_sticker_cremedemarrons_351x201.jpg", Texture.TEXTURE_DIRECTION_VERTICAL, Texture.TEXTURE_ORIENTATION_NORMAL, Texture.TEXTURE_ORIENTATION_OPPOSITE);
+		//Texture texearth = new Texture("resources/texture/texture_earthtruecolor_nasa_big_2048x1024.jpg");
+		//Texture texmoon = new Texture("resources/texture/texture_moon_2048x1024.jpg");
+		Texture texfoot = new Texture("resources/texture/texture_football_320x160.jpg");
+		Texture texcarpet = new Texture("resources/texture/texture_carpet_600x600.jpg");
+	
+		// Camera
+		Vector4 eye = new Vector4(10,6,3,1);
+		Vector4 poi = new Vector4(0,0,0,1);
+		Camera camera = new Camera(eye, poi, Vector4.Z_AXIS);		
+				
+		TestMultiElementsTextureShadows test = new TestMultiElementsTextureShadows();
+				
+		// Create a new World
+		System.out.println("********* Creating World");
+		World world = new World();
+		world.setBackgroundColor(Color.BLACK);
+		Element e;
+		
+		for (int i=-1; i<=1; i++) {
+			for (int j=-1; j<=1; j++) {
+				for (int k=-1; k<=1; k++) {
+										
+					// Create an Element of a random type
+					switch((int)(Math.random()*7)) {
+					case 0:
+						e = new Cone(1,0.5f,32, texdamier);
+						break;
+						
+					case 1:
+						e = new Cylinder(1,0.5f,32, texcremedemarron);
+						break;
+						
+					case 2:
+						e = new Sphere(0.667f,32, texfoot);
+						e.setSpecularExp(3);
+						e.setSpecularColor(new Color(100,100,100));
+						e.setColor(new Color(200,150,255));
+						break;
+						
+					case 3:
+						e = new Cube(1, texmetalplate);
+						break;
+						
+					case 4:
+						e = new Box(1.5f,1,0.5f, texbricks);
+						break;
+						
+					case 5:
+						
+						float size = 1.5f;
+						int n = 10;
+						int nb_sin = 2;
+						float array[][] = new float[n+1][n+1];
+						for (int p=0; p<=n; p++) {
+							for (int q=0; q<=n; q++) {
+								float a = (float)Math.PI*(float)nb_sin*(float)p/(float)n;
+								float b = (float)Math.PI*(float)nb_sin*(float)q/(float)n;
+								array[p][q] = size*(float)Math.sin(a)*(float)Math.sin(b)/((float)nb_sin*2);
+
+							}
+						}
+						e = null;
+						try {
+							e = new Trellis(size, size, n, n, array, texgrass);
+						} catch (WrongArraySizeException ex) {
+							// TODO Auto-generated catch block
+							ex.printStackTrace();
+						}
+						break;
+					case 6:
+						e = new Pyramid(1.4f, 1.4f, 1.4f, texcarpet);
+						break;
+						
+					default:
+						e = null;
+					}
+					
+					// Translate this element at some i,j,k indices of a 3D cube:
+					Translation t = new Translation(new Vector3(i*2, j*2, k*2));
+					e.setTransformation(t);
+
+					// Add the element to the world
+					world.addElement(e);
+				}
+			}
+		}
+		
+		// Generate world and normals
+		world.build();
+
+		// Print World characteristics on console
+		System.out.println(world);
+		for (int i=0; i<world.getNbElements(); i++)
+			System.out.println(world.getElement(i));
+
+		// Create lighting
+		System.out.println("********* Creating Lighting");
+		DirectionalLight dl = new DirectionalLight(new Vector3(-1,0.5f,-0.5f), 0.7f);
+		AmbientLight al = new AmbientLight(0.3f);
+		Lighting lighting = new Lighting(dl, al, true);
+
+		PerspectiveContext context = new PerspectiveContext(1.5f, 0.9f, 1, 100, PerspectiveContext.PERSPECTIVE_TYPE_FRUSTUM, 1000);
+		GUIView gUIView = test.createView(context);
+
+		RenderContext rContext = new RenderContext(RenderContext.RENDER_STANDARD_INTERPOLATE_WITH_LANDMARKS);
+		rContext.setTextureProcessing(RenderContext.TEXTURE_PROCESSING_ENABLED);
+		rContext.setShadowing(RenderContext.SHADOWING_ENABLED);
+		//rContext.setRenderingLines(RenderContext.RENDERING_LINES_ENABLED);
+		//rContext.setDisplayNormals(RenderContext.DISPLAY_NORMALS_ENABLED);
+		
+		RenderEngine renderer = new RenderEngine(world, lighting, camera, rContext, context);
+		renderer.setView(gUIView);
+		renderer.render();
+		
+		System.out.println("********* Rendering...");
+		int nb_images = 360;
+		Rotation r1 = new Rotation((float)Math.PI*2/(float)nb_images, Vector3.X_AXIS);
+		Rotation r2 = new Rotation((float)Math.PI*2*1.5f/(float)nb_images, Vector3.Y_AXIS);
+		Rotation r3 = new Rotation((float)Math.PI*2*2.5f/(float)nb_images, Vector3.Z_AXIS);
+		Transformation r = new Transformation(r1.times(r2).times(r3));
+		for (int i=0; i<=nb_images; i++) {
+			world.expandTransformation(r);
+			renderer.render();
+		}
+
+		System.out.println("********* ENDING APPLICATION *********");
+
+	}
+}

--- a/src/com/aventura/test/TestShadowMapRasterization.java
+++ b/src/com/aventura/test/TestShadowMapRasterization.java
@@ -125,13 +125,13 @@ public class TestShadowMapRasterization {
 		System.out.println("********* Creating World");
 		//Texture tex1 = new Texture("resources/texture/texture_bricks_204x204.jpg");
 		//Texture tex3 = new Texture("resources/texture/texture_blueground_204x204.jpg");
-		//Texture tex2 = new Texture("resources/texture/texture_woodfloor_160x160.jpg");
+		Texture tex2 = new Texture("resources/texture/texture_woodfloor_160x160.jpg");
 		
 		World world = new World();
 		
 		// ----- Trellis
-		//Trellis trellis = new Trellis(8, 8, 10, 10, tex2);
-		Trellis trellis = new Trellis(8, 8, 10, 10);
+		Trellis trellis = new Trellis(8, 8, 10, 10, tex2);
+		//Trellis trellis = new Trellis(8, 8, 10, 10);
 		world.addElement(trellis);
 		
 		// ----- Cube
@@ -169,7 +169,7 @@ public class TestShadowMapRasterization {
 		//DirectionalLight dl2 = new DirectionalLight(new Vector3(-2,-1,-0.1f), ShadowingLight.SHADOWING_BOX_WORLD);
 		
 		DirectionalLight dl = new DirectionalLight(new Vector3(2,-1,-2f), ShadowingLight.SHADOWING_BOX_WORLD);
-		DirectionalLight dl2 = new DirectionalLight(new Vector3(-2,-1,-2f), ShadowingLight.SHADOWING_BOX_WORLD);
+		DirectionalLight dl2 = new DirectionalLight(new Vector3(-2,-2,-0.5f), ShadowingLight.SHADOWING_BOX_WORLD);
 		
 		//DirectionalLight dl = new DirectionalLight(new Vector3(1,3,2));
 		//Lighting light = new Lighting(dl, al);
@@ -206,27 +206,27 @@ public class TestShadowMapRasterization {
 		System.out.println(renderer.renderStats());
 		
 		// --- TEMPORARY DEBUG PROBE ---
-		System.out.println("Shadow probe for dl (grid over the Trellis, z=0):");
-		int steps = 41; // odd, so 0,0 falls exactly on a sample
-		for (int j = steps - 1; j >= 0; j--) {
-		    float y = -4f + 8f * j / (steps - 1); // trellis is 8x8, centered
-		    StringBuilder line = new StringBuilder();
-		    for (int i = 0; i < steps; i++) {
-		        float x = -4f + 8f * i / (steps - 1);
-		        Vector4 p = new Vector4(x, y, 0, 1);
-		        float factor = dl.shadowFactorAt(p);
-		        line.append(factor > 0 ? '.' : '#');
-		    }
-		    System.out.println(line.toString());
-		}
-		System.out.println("--- END PROBE ---");
-		try {
-			probePoint(dl, 0.2f, 0f);
-			probePoint(dl, 0.6f, 0f);
-			} catch (Exception e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
+//		System.out.println("Shadow probe for dl (grid over the Trellis, z=0):");
+//		int steps = 41; // odd, so 0,0 falls exactly on a sample
+//		for (int j = steps - 1; j >= 0; j--) {
+//		    float y = -4f + 8f * j / (steps - 1); // trellis is 8x8, centered
+//		    StringBuilder line = new StringBuilder();
+//		    for (int i = 0; i < steps; i++) {
+//		        float x = -4f + 8f * i / (steps - 1);
+//		        Vector4 p = new Vector4(x, y, 0, 1);
+//		        float factor = dl.shadowFactorAt(p);
+//		        line.append(factor > 0 ? '.' : '#');
+//		    }
+//		    System.out.println(line.toString());
+//		}
+//		System.out.println("--- END PROBE ---");
+//		try {
+//			probePoint(dl, 0.2f, 0f);
+//			probePoint(dl, 0.6f, 0f);
+//			} catch (Exception e) {
+//			// TODO Auto-generated catch block
+//			e.printStackTrace();
+//		}
 
 		
 		Scanner sc = new Scanner(System.in);
@@ -262,29 +262,29 @@ public class TestShadowMapRasterization {
 	
 
 
-//TEMPORARY: duplicate of shadowFactorAt()'s logic, but printing every intermediate value
-static void probePoint(DirectionalLight dl, float x, float y) throws Exception {
- java.lang.reflect.Field vpField = com.aventura.model.light.ShadowingLight.class.getDeclaredField("viewProjection_light");
- vpField.setAccessible(true);
- com.aventura.engine.ViewProjection vp = (com.aventura.engine.ViewProjection) vpField.get(dl);
-
- java.lang.reflect.Field mapField = com.aventura.model.light.ShadowingLight.class.getDeclaredField("map");
- mapField.setAccessible(true);
- com.aventura.view.MapView map = (com.aventura.view.MapView) mapField.get(dl);
-
- java.lang.reflect.Field biasField = com.aventura.model.light.ShadowingLight.class.getDeclaredField("ndcShadowBias");
- biasField.setAccessible(true);
- float bias = biasField.getFloat(dl);
-
- Vector4 p = new Vector4(x, y, 0, 1);
- Vector4 pls = vp.project(p);
- float s = (pls.getX() + 1) / 2;
- float t = (pls.getY() + 1) / 2;
- float depth = map.getInterpolation(s, t);
-
- System.out.println("Point (" + x + "," + y + "): posInLightSpace=" + pls
-     + " s=" + s + " t=" + t + " sampledDepth=" + depth
-     + " queryZ=" + pls.getZ() + " bias=" + bias
-     + " => " + (pls.getZ() > depth + bias ? "SHADOW" : "LIT"));
-}
+////TEMPORARY: duplicate of shadowFactorAt()'s logic, but printing every intermediate value
+//static void probePoint(DirectionalLight dl, float x, float y) throws Exception {
+// java.lang.reflect.Field vpField = com.aventura.model.light.ShadowingLight.class.getDeclaredField("viewProjection_light");
+// vpField.setAccessible(true);
+// com.aventura.engine.ViewProjection vp = (com.aventura.engine.ViewProjection) vpField.get(dl);
+//
+// java.lang.reflect.Field mapField = com.aventura.model.light.ShadowingLight.class.getDeclaredField("map");
+// mapField.setAccessible(true);
+// com.aventura.view.MapView map = (com.aventura.view.MapView) mapField.get(dl);
+//
+// java.lang.reflect.Field biasField = com.aventura.model.light.ShadowingLight.class.getDeclaredField("ndcShadowBias");
+// biasField.setAccessible(true);
+// float bias = biasField.getFloat(dl);
+//
+// Vector4 p = new Vector4(x, y, 0, 1);
+// Vector4 pls = vp.project(p);
+// float s = (pls.getX() + 1) / 2;
+// float t = (pls.getY() + 1) / 2;
+// float depth = map.getInterpolation(s, t);
+//
+// System.out.println("Point (" + x + "," + y + "): posInLightSpace=" + pls
+//     + " s=" + s + " t=" + t + " sampledDepth=" + depth
+//     + " queryZ=" + pls.getZ() + " bias=" + bias
+//     + " => " + (pls.getZ() > depth + bias ? "SHADOW" : "LIT"));
+//}
 }

--- a/src/com/aventura/test/TestShadowMapRasterization.java
+++ b/src/com/aventura/test/TestShadowMapRasterization.java
@@ -165,8 +165,10 @@ public class TestShadowMapRasterization {
 		
 		//DirectionalLight dl = new DirectionalLight(new Vector3(0,1,2));
 		AmbientLight al = new AmbientLight(0.1f);
-		DirectionalLight dl = new DirectionalLight(new Vector3(2,-1,-0.1f), ShadowingLight.SHADOWING_BOX_WORLD);
-		DirectionalLight dl2 = new DirectionalLight(new Vector3(-2,-1,-0.1f), ShadowingLight.SHADOWING_BOX_WORLD);
+		//DirectionalLight dl = new DirectionalLight(new Vector3(2,-1,-0.1f), ShadowingLight.SHADOWING_BOX_WORLD);
+		//DirectionalLight dl2 = new DirectionalLight(new Vector3(-2,-1,-0.1f), ShadowingLight.SHADOWING_BOX_WORLD);
+		DirectionalLight dl = new DirectionalLight(new Vector3(2,-1,-2f), ShadowingLight.SHADOWING_BOX_WORLD);
+		DirectionalLight dl2 = new DirectionalLight(new Vector3(-2,-1,-2f), ShadowingLight.SHADOWING_BOX_WORLD);
 		//DirectionalLight dl = new DirectionalLight(new Vector3(1,3,2));
 		//Lighting light = new Lighting(dl, al);
 		Lighting light = new Lighting(al);

--- a/src/com/aventura/test/TestShadowMapRasterization.java
+++ b/src/com/aventura/test/TestShadowMapRasterization.java
@@ -167,13 +167,17 @@ public class TestShadowMapRasterization {
 		AmbientLight al = new AmbientLight(0.1f);
 		//DirectionalLight dl = new DirectionalLight(new Vector3(2,-1,-0.1f), ShadowingLight.SHADOWING_BOX_WORLD);
 		//DirectionalLight dl2 = new DirectionalLight(new Vector3(-2,-1,-0.1f), ShadowingLight.SHADOWING_BOX_WORLD);
+		
 		DirectionalLight dl = new DirectionalLight(new Vector3(2,-1,-2f), ShadowingLight.SHADOWING_BOX_WORLD);
 		DirectionalLight dl2 = new DirectionalLight(new Vector3(-2,-1,-2f), ShadowingLight.SHADOWING_BOX_WORLD);
+		
 		//DirectionalLight dl = new DirectionalLight(new Vector3(1,3,2));
 		//Lighting light = new Lighting(dl, al);
 		Lighting light = new Lighting(al);
+		
 		light.addDirectionalLight(dl);
 		light.addDirectionalLight(dl2);
+		
 		//light.setDirectionalLight(dl);
 		//Lighting light = new Lighting(dl);
 		
@@ -200,6 +204,30 @@ public class TestShadowMapRasterization {
 		MapView map = renderer.render();
 		System.out.println("ZBuffer min: "+map.getMin() + ", ZBuffer max: "+map.getMax() + ", ZBuffer avg: " + map.getAverage() + ". Nb of Pixels around min: " + map.getNbOfPixelsInRange(map.getMin(), map.getMin()+0.01f*(map.getMax()-map.getMin())) + ". Nb of Pixels around max: " + map.getNbOfPixelsInRange(map.getMax()-0.01f*(map.getMax()-map.getMin()), map.getMax())+ ". Nb of Pixels in map: " + map.getNbOfPixels());
 		System.out.println(renderer.renderStats());
+		
+		// --- TEMPORARY DEBUG PROBE ---
+		System.out.println("Shadow probe for dl (grid over the Trellis, z=0):");
+		int steps = 41; // odd, so 0,0 falls exactly on a sample
+		for (int j = steps - 1; j >= 0; j--) {
+		    float y = -4f + 8f * j / (steps - 1); // trellis is 8x8, centered
+		    StringBuilder line = new StringBuilder();
+		    for (int i = 0; i < steps; i++) {
+		        float x = -4f + 8f * i / (steps - 1);
+		        Vector4 p = new Vector4(x, y, 0, 1);
+		        float factor = dl.shadowFactorAt(p);
+		        line.append(factor > 0 ? '.' : '#');
+		    }
+		    System.out.println(line.toString());
+		}
+		System.out.println("--- END PROBE ---");
+		try {
+			probePoint(dl, 0.2f, 0f);
+			probePoint(dl, 0.6f, 0f);
+			} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+
 		
 		Scanner sc = new Scanner(System.in);
 		System.out.println("Please type return for Shadow Maps...");
@@ -232,4 +260,31 @@ public class TestShadowMapRasterization {
 		System.out.println("********* ENDING APPLICATION *********");
 	}
 	
+
+
+//TEMPORARY: duplicate of shadowFactorAt()'s logic, but printing every intermediate value
+static void probePoint(DirectionalLight dl, float x, float y) throws Exception {
+ java.lang.reflect.Field vpField = com.aventura.model.light.ShadowingLight.class.getDeclaredField("viewProjection_light");
+ vpField.setAccessible(true);
+ com.aventura.engine.ViewProjection vp = (com.aventura.engine.ViewProjection) vpField.get(dl);
+
+ java.lang.reflect.Field mapField = com.aventura.model.light.ShadowingLight.class.getDeclaredField("map");
+ mapField.setAccessible(true);
+ com.aventura.view.MapView map = (com.aventura.view.MapView) mapField.get(dl);
+
+ java.lang.reflect.Field biasField = com.aventura.model.light.ShadowingLight.class.getDeclaredField("ndcShadowBias");
+ biasField.setAccessible(true);
+ float bias = biasField.getFloat(dl);
+
+ Vector4 p = new Vector4(x, y, 0, 1);
+ Vector4 pls = vp.project(p);
+ float s = (pls.getX() + 1) / 2;
+ float t = (pls.getY() + 1) / 2;
+ float depth = map.getInterpolation(s, t);
+
+ System.out.println("Point (" + x + "," + y + "): posInLightSpace=" + pls
+     + " s=" + s + " t=" + t + " sampledDepth=" + depth
+     + " queryZ=" + pls.getZ() + " bias=" + bias
+     + " => " + (pls.getZ() > depth + bias ? "SHADOW" : "LIT"));
+}
 }


### PR DESCRIPTION
Multiple improvements and fixes are now completed and have definitely stabilized the Shadowing feature.
It is now mature enough before starting future round of evolutions and improvements.

Here is the backlog so far :
# Backlog — Aventura RenderEngine (Shadow Mapping)

## Shadow mapping / lights
1. **Rectangular shadow maps** — requires revisiting `ZBuffer` + `ShadowingLight.generateShadowMap()`, which currently assume a square map (forced square today to match `ZBuffer`'s `map_size x map_size` allocation).
2. **PCF (Percentage Closer Filtering)** — replace `shadowFactorAt()`'s binary test with a multi-texel averaged sample, to smooth out shadow-edge aliasing. Requires: `shadowFactorAt()` to return a continuous `float` instead of `0`/`1`, and `ShadingConsumer` to move from a "skip if `<=0`" pattern to a weighted per-light accumulation (dedicated scratch accumulator). *(priority raised, next step after the current resolution test)*
3. **Acne on vertical object faces** (e.g. the cube's face) at grazing angles — check whether the slope-scaled bias fix already in place is sufficient, or needs adjusting/extending. *(currently under investigation)*
4. **Implement `SHADOWING_BOX_ELEMENT` and `SHADOWING_BOX_SPECIFIC`** — currently fall back to `SHADOWING_BOX_WORLD`.
5. **`PointLight`/`SpotLight`** — `getLightVectorAtPoint`, `getIntensity`, `initShadowing` are still empty stubs; to be addressed once `DirectionalLight` is fully validated.

## Configuration / parameterization
6. **Group the currently hardcoded tuning constants** and expose them through the configuration system (`PerspectiveContext`/`RenderContext`): `DEFAULT_SHADOW_MAP_DIMENSION`, `SHADOW_BIAS_WORLD`, `DOT_NL_FLOOR`, and any future similar tuning constant — to be handled as a batch rather than one-off.

## Architecture / refactoring
7. **Merge `ZBuffer` into `MapView`** — `ZBuffer` is conceptually "just" a Map; consider folding it into the `MapView` hierarchy, with renames if needed, and a possible move to `com.aventura.view`. *(on hold during the shadow map investigation)*

## Minor code quality
8. **`TriangleRasterizer`** — uses `(int)` (truncation) instead of `Math.floor()` for screen Y coordinates, which can be negative — an asymmetric sub-pixel rounding bias, unrelated to the bugs we chased but worth fixing for consistency.